### PR TITLE
add more Test Cases and Apache Licence Text to EqualsIgnoreCaseFunctionExtension

### DIFF
--- a/modules/siddhi-extensions/string/src/main/java/org/wso2/siddhi/extension/string/EqualsIgnoreCaseFunctionExtension.java
+++ b/modules/siddhi-extensions/string/src/main/java/org/wso2/siddhi/extension/string/EqualsIgnoreCaseFunctionExtension.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.extension.string;
+
+import org.wso2.siddhi.core.config.ExecutionPlanContext;
+import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.ExecutionPlanValidationException;
+
+/**
+ * equalsIgnoreCase(string, compareTo)
+ * Compares two strings lexicographically.
+ * Accept Type(s): (STRING,STRING)
+ * Return Type(s): BOOL
+ */
+public class EqualsIgnoreCaseFunctionExtension extends FunctionExecutor {
+    Attribute.Type returnType = Attribute.Type.BOOL;
+
+    @Override
+    public Attribute.Type getReturnType() {
+        // TODO Auto-generated method stub
+        return returnType;
+    }
+
+    @Override
+    public void start() {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void stop() {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public Object[] currentState() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void restoreState(Object[] state) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    protected void init(ExpressionExecutor[] attributeExpressionExecutors, ExecutionPlanContext executionPlanContext) {
+        // TODO Auto-generated method stub
+        if (attributeExpressionExecutors.length != 2) {
+            throw new ExecutionPlanValidationException(
+                    "Invalid no of arguments passed to str:equalsIgnoreCase() function, " + "required 2, but found "
+                            + attributeExpressionExecutors.length);
+        }
+        if (attributeExpressionExecutors[0].getReturnType() != Attribute.Type.STRING) {
+            throw new ExecutionPlanValidationException(
+                    "Invalid parameter type found for the first argument of str:equalsIgnoreCase() function, "
+                            + "required " + Attribute.Type.STRING + ", but found "
+                            + attributeExpressionExecutors[0].getReturnType().toString());
+        }
+        if (attributeExpressionExecutors[1].getReturnType() != Attribute.Type.STRING) {
+            throw new ExecutionPlanValidationException(
+                    "Invalid parameter type found for the second argument of str:equalsIgnoreCase()) function, "
+                            + "required " + Attribute.Type.STRING + ", but found "
+                            + attributeExpressionExecutors[1].getReturnType().toString());
+        }
+
+    }
+
+    @Override
+    protected Object execute(Object[] data) {
+        // TODO Auto-generated method stub
+        if (data[0] == null) {
+            throw new ExecutionPlanRuntimeException(
+                    "Invalid input given to str:equalsIgnoreCase() function. First argument cannot be null");
+        }
+        String source = (String) data[0];
+        String compareTo = (String) data[1];
+        return source.equalsIgnoreCase(compareTo);
+    }
+
+    @Override
+    protected Object execute(Object data) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/modules/siddhi-extensions/string/src/main/resources/str.siddhiext
+++ b/modules/siddhi-extensions/string/src/main/resources/str.siddhiext
@@ -33,3 +33,4 @@ upper=org.wso2.siddhi.extension.string.UpperFunctionExtension
 hex=org.wso2.siddhi.extension.string.HexFunctionExtension
 unhex=org.wso2.siddhi.extension.string.UnhexFunctionExtension
 contains=org.wso2.siddhi.extension.string.ContainsFunctionExtension
+equalsIgnoreCase=org.wso2.siddhi.extension.string.EqualsIgnoreCaseFunctionExtension

--- a/modules/siddhi-extensions/string/src/test/java/org/wso2/siddhi/extension/string/EqualsIgnoreCaseFunctionExtensionTestCase.java
+++ b/modules/siddhi-extensions/string/src/test/java/org/wso2/siddhi/extension/string/EqualsIgnoreCaseFunctionExtensionTestCase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.extension.string;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import junit.framework.Assert;
+
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.ExecutionPlanRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.extension.string.test.util.SiddhiTestHelper;
+
+public class EqualsIgnoreCaseFunctionExtensionTestCase {
+    static final Logger log = Logger.getLogger(EqualsIgnoreCaseFunctionExtensionTestCase.class);
+    private AtomicInteger count = new AtomicInteger(0);
+    private volatile boolean eventArrived;
+
+    @Before
+    public void init() {
+        count.set(0);
+        eventArrived = false;
+    }
+
+    @Test
+    public void testContainsFunctionExtension() throws InterruptedException {
+        log.info("EqualsIgnoreCaseFunctionExtensionTestCase TestCase");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "@config(async = 'true')define stream inputStream (symbol string, price long, "
+                + "volume long);";
+        String query = ("@info(name = 'query1') " + "from inputStream "
+                + "select symbol , str:equalsIgnoreCase(symbol, 'WSO2') as isEqualIgnoreCase "
+                + "insert into outputStream;");
+        ExecutionPlanRuntime executionPlanRuntime = siddhiManager
+                .createExecutionPlanRuntime(inStreamDefinition + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event inEvent : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        Assert.assertEquals(false, inEvent.getData(1));
+                    }
+                    if (count.get() == 2) {
+                        Assert.assertEquals(true, inEvent.getData(1));
+                    }
+                    if (count.get() == 3) {
+                        Assert.assertEquals(true, inEvent.getData(1));
+                    }
+                    if (count.get() == 4) {
+                        Assert.assertEquals(false, inEvent.getData(1));
+                    }
+                    eventArrived = true;
+                }
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+        inputHandler.send(new Object[] { "IBM", 700f, 100l });
+        inputHandler.send(new Object[] { "WSO2", 60.5f, 200l });
+        inputHandler.send(new Object[] { "wso2", 60.5f, 200l });
+        inputHandler.send(new Object[] { "", 60.5f, 200l });
+        SiddhiTestHelper.waitForEvents(100, 4, count, 60000);
+        Assert.assertEquals(4, count.get());
+        Assert.assertTrue(eventArrived);
+        executionPlanRuntime.shutdown();
+    }
+}


### PR DESCRIPTION
Implemented str:equalsIgnoreCase(String, toAnotherString) string function which is similar to JAVA 
<public boolean equalsIgnoreCase(String anotherString)>
function