### PR TITLE
CEP-1411 Support to customize exception handler for disruptor in siddhi when creating ExecutionPlanRuntime

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/ExecutionPlanRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/ExecutionPlanRuntime.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.siddhi.core;
 
+import com.lmax.disruptor.ExceptionHandler;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.ExecutionPlanContext;
 import org.wso2.siddhi.core.exception.DefinitionNotExistException;
@@ -214,5 +215,9 @@ public class ExecutionPlanRuntime {
                                 query.getKey());
             }
         }
+    }
+
+    public void handleExceptionWith(ExceptionHandler<Object> exceptionHandler) {
+        executionPlanContext.setExceptionHandler(exceptionHandler);
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/ExecutionPlanContext.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/ExecutionPlanContext.java
@@ -18,6 +18,7 @@
 
 package org.wso2.siddhi.core.config;
 
+import com.lmax.disruptor.ExceptionHandler;
 import org.wso2.siddhi.core.function.EvalScript;
 import org.wso2.siddhi.core.util.ElementIdGenerator;
 import org.wso2.siddhi.core.util.extension.holder.EternalReferencedHolder;
@@ -54,6 +55,7 @@ public class ExecutionPlanContext {
     private PersistenceService persistenceService;
     private ElementIdGenerator elementIdGenerator;
     private Map<String, EvalScript> scriptFunctionMap;
+    private ExceptionHandler<Object> exceptionHandler;
 
     public ExecutionPlanContext() {
         this.eternalReferencedHolders = new ArrayList<EternalReferencedHolder>();
@@ -189,4 +191,11 @@ public class ExecutionPlanContext {
     }
 
 
+    public void setExceptionHandler(ExceptionHandler<Object> exceptionHandler) {
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    public ExceptionHandler<Object> getExceptionHandler() {
+        return this.exceptionHandler;
+    }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/output/callback/QueryCallback.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/output/callback/QueryCallback.java
@@ -168,6 +168,7 @@ public abstract class QueryCallback {
                         executionPlanContext.getExecutorService());
             }
             asyncEventHandler = new AsyncEventHandler(this);
+            disruptor.handleExceptionsWith(executionPlanContext.getExceptionHandler());
             disruptor.handleEventsWith(asyncEventHandler);
             ringBuffer = disruptor.start();
         }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/StreamJunction.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/StreamJunction.java
@@ -229,12 +229,14 @@ public class StreamJunction {
                         disruptor = new Disruptor<Event>(new EventFactory(streamDefinition.getAttributeList().size()),
                                 bufferSize, executorService, producerType,
                                 PhasedBackoffWaitStrategy.withLiteLock(1, 4, TimeUnit.SECONDS));
+                        disruptor.handleExceptionsWith(executionPlanContext.getExceptionHandler());
                         break;
                     }
                 }
                 if (disruptor == null) {
                     disruptor = new Disruptor<Event>(new EventFactory(streamDefinition.getAttributeList().size()),
                             bufferSize, executorService);
+                    disruptor.handleExceptionsWith(executionPlanContext.getExceptionHandler());
                 }
                 for (Receiver receiver : receivers) {
                     disruptor.handleEventsWith(new StreamHandler(receiver));

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/SingleStreamEntryValve.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/SingleStreamEntryValve.java
@@ -149,22 +149,24 @@ public class SingleStreamEntryValve implements InputProcessor {
 
         private void sendEvents() {
             int size = eventBuffer.size();
-            switch (size) {
-                case 0: {
-                    return;
+            try {
+                switch (size) {
+                    case 0: {
+                        return;
+                    }
+                    case 1: {
+                        inputProcessor.send(eventBuffer.get(0), currentIndex);
+                        eventBuffer.clear();
+                        return;
+                    }
+                    default: {
+                        inputProcessor.send(eventBuffer.toArray(new Event[size]), currentIndex);
+                    }
                 }
-                case 1: {
-                    inputProcessor.send(eventBuffer.get(0), currentIndex);
-                    eventBuffer.clear();
-                    return;
-                }
-                default: {
-                    inputProcessor.send(eventBuffer.toArray(new Event[size]), currentIndex);
-                    eventBuffer.clear();
-                }
+            } finally {
+                if(size>0) eventBuffer.clear();
             }
         }
-
     }
 
     public static class IndexedEventFactory implements com.lmax.disruptor.EventFactory<IndexedEventFactory.IndexedEvent> {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/StreamCallback.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/StreamCallback.java
@@ -155,6 +155,7 @@ public abstract class StreamCallback implements StreamJunction.Receiver {
                         executionPlanContext.getSiddhiContext().getEventBufferSize(),
                         executionPlanContext.getExecutorService());
             }
+            disruptor.handleExceptionsWith(executionPlanContext.getExceptionHandler());
             asyncEventHandler = new AsyncEventHandler(this);
             disruptor.handleEventsWith(asyncEventHandler);
             ringBuffer = disruptor.start();

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/ExceptionHandlerTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/ExceptionHandlerTestCase.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.siddhi.core.stream;
+
+import com.lmax.disruptor.ExceptionHandler;
+import junit.framework.Assert;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.ExecutionPlanRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+public class ExceptionHandlerTestCase {
+
+    static final Logger log = Logger.getLogger(CallbackTestCase.class);
+    private volatile int count;
+    private volatile boolean eventArrived;
+    private volatile int failedCount;
+    private volatile boolean failedCaught;
+
+    @Before
+    public void init() {
+        count = 0;
+        eventArrived = false;
+        failedCount = 0;
+        failedCaught = false;
+    }
+
+    private ExecutionPlanRuntime createTestExecutionRuntime(){
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String executionPlan = "" +
+                "@Plan:name('callbackTest1') " +
+                "" +
+                "define stream StockStream (symbol string, price float, volume long);" +
+                "" +
+                "@info(name = 'query1') " +
+                "@Parallel " +
+                "from StockStream[price + 0.0 > 0.0] " +
+                "select symbol, price " +
+                "insert into outputStream;";
+
+        ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(executionPlan);
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp,inEvents,removeEvents);
+                count = count + inEvents.length;
+                eventArrived = true;
+            }
+        });
+
+//        executionPlanRuntime.addCallback("outputStream", new StreamCallback() {
+//            @Override
+//            public void receive(Event[] events) {
+//                EventPrinter.print(events);
+//                count = count + events.length;
+//                eventArrived = true;
+//            }
+//        });
+        return executionPlanRuntime;
+    }
+
+    /**
+     * Send 6 test events (3 batches x 2 events per batch)
+     *
+     * @param inputHandler input handler
+     * @throws Exception
+     */
+    private void sendTestInvalidEvents(InputHandler inputHandler ) throws Exception {
+        // Send 2 valid events
+        inputHandler.send(0,new Object[]{"GOOD_0", 700.0f, 100l});
+        Thread.sleep(5);
+        inputHandler.send(1,new Object[]{"GOOD_1", 60.5f, 200l});
+        Thread.sleep(5);
+        try {
+            // Send 2 invalid event
+            inputHandler.send(3,new Object[]{"BAD_2", "EBAY", 200l});
+            Thread.sleep(5);
+            inputHandler.send(4,new Object[]{"BAD_3", "WSO2",700f});
+            Thread.sleep(5);
+        }catch (Exception ex){
+            Assert.fail("Disruptor exception can't be caught by try-catch");
+            throw ex;
+        }
+        // Send 2 valid events
+        inputHandler.send(5,new Object[]{"GOOD_4", 700.0f, 100l});
+        Thread.sleep(5);
+        inputHandler.send(6,new Object[]{"GOOD_5", 60.5f, 200l});
+        Thread.sleep(5);
+    }
+
+    private void sendTestValidEvents(InputHandler inputHandler ) throws Exception {
+        // Send 2 valid events
+        inputHandler.send(new Object[]{"IBM", 700.0f, 100l});
+        Thread.sleep(5);
+        inputHandler.send(new Object[]{"WSO2", 60.5f, 200l});
+        Thread.sleep(5);
+        // Send 2 valid event
+        inputHandler.send(new Object[]{"IBM", 700.0f, 100l});
+        Thread.sleep(5);
+        inputHandler.send(new Object[]{"WSO2", 60.5f, 200l});
+        Thread.sleep(5);
+        // Send 2 valid events
+        inputHandler.send(new Object[]{"IBM", 700.0f, 100l});
+        Thread.sleep(5);
+        inputHandler.send(new Object[]{"WSO2", 60.5f, 200l});
+        Thread.sleep(5);
+    }
+
+    @Test
+    public void callbackTestForValidEvents() throws Exception {
+        log.info("callback test without exception handler");
+        ExecutionPlanRuntime executionPlanRuntime = createTestExecutionRuntime();
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("StockStream");
+        executionPlanRuntime.start();
+
+        sendTestValidEvents(inputHandler);
+
+        Thread.sleep(100);
+
+        Assert.assertTrue(eventArrived);
+        Assert.assertEquals(6, count);
+        Assert.assertFalse(failedCaught);
+        Assert.assertEquals(0, failedCount);
+        executionPlanRuntime.shutdown();
+    }
+
+    @Test
+    public void callbackTestForInvalidEventWithoutExceptionHandler() throws Exception {
+        log.info("callback test without exception handler");
+        ExecutionPlanRuntime executionPlanRuntime = createTestExecutionRuntime();
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("StockStream");
+        executionPlanRuntime.start();
+        sendTestInvalidEvents(inputHandler);
+
+        Thread.sleep(100);
+
+        Assert.assertTrue("Can only get the first 2 events, because disruptor crashes after caught with exception",eventArrived);
+        Assert.assertEquals("Can only get the first 2 events, because disruptor crashes after caught with exception",2, count);
+        Assert.assertFalse("Can't catch disruptor exception by try-catch",failedCaught);
+        Assert.assertEquals("Can't catch disruptor exception by try-catch",0, failedCount);
+        executionPlanRuntime.shutdown();
+    }
+
+
+    @Test
+    public void callbackTestForInvalidEventWithExceptionHandler() throws Exception {
+        log.info("callback test with exception handler");
+        ExecutionPlanRuntime executionPlanRuntime = createTestExecutionRuntime();
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("StockStream");
+        executionPlanRuntime.handleExceptionWith(new ExceptionHandler<Object>() {
+            @Override
+            public void handleEventException(Throwable throwable, long l, Object o) {
+                failedCount ++;
+                failedCaught = true;
+                log.info(o+": properly handle event exception for bad event [sequence: " + l + ", failed: "+failedCount+"]", throwable);
+            }
+
+            @Override
+            public void handleOnStartException(Throwable throwable) {
+                failedCount ++;
+                failedCaught = true;
+            }
+
+            @Override
+            public void handleOnShutdownException(Throwable throwable) {
+                log.info("Properly handle shutdown exception", throwable);
+                failedCount++;
+                failedCaught = true;
+            }
+        });
+
+        executionPlanRuntime.start();
+        sendTestInvalidEvents(inputHandler);
+        Thread.sleep(Long.MAX_VALUE);
+        // No following events can be processed correctly
+        Assert.assertTrue("Should properly process all the 4 valid events",eventArrived);
+        Assert.assertEquals("Should properly process all the 4 valid events",4, count);
+        Assert.assertTrue("Exception is properly handled thrown by 2 invalid events",failedCaught);
+        Assert.assertEquals("Exception is properly handled thrown by 2 invalid events",2, failedCount);
+        executionPlanRuntime.shutdown();
+    }
+}


### PR DESCRIPTION
## Problem
- https://issues.apache.org/jira/browse/EAGLE-41
- https://wso2.org/jira/browse/CEP-1411

We are running siddhi(v3.0.2) on storm, but found siddhi engine will throw RuntimeException and crash when receive an invalid input.What's more, any invalid input will block the whole topology, also for siddhi are using async callback with disruptor, we are not able to catch these exception by try-catch. The Unit Test here https://github.com/haoch/siddhi/blob/ce5ffcf9368f63d8af2072c4666b8c3e938a93be/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/ExceptionHandlerTestCase.java#L127-L141 proves the disruptor thread crashes while caught with exception, which means that the problem has not been resolved completely

## Root Cause
The root cause is that Siddhi is relying on [Disruptor](https://lmax-exchange.github.io/disruptor/) while disruptor is running in async thread and the default exception handler strategy is [`com.lmax.disruptor.FatalExceptionHandler`](https://github.com/LMAX-Exchange/disruptor/blob/master/src/main/java/com/lmax/disruptor/BatchEventProcessor.java#L34) which means the thread will crash once caught with any exception. In such situation, siddhi instance will fail to dead once receiving any invalid events and dev/user could do nothing but force to restart the runtime, especially in a distributed environment like storm, it's very hard for maintenance and lack of reliability.

## Solution
The solution is very straight-forward: Support to customize exception handler for disruptor in siddhi when creating ExecutionPlanRuntime.
~~~java
public class ExecutionPlanRuntime {
 // ... 
 public void handleExceptionWith(ExceptionHandler<Object> exceptionHandler)
}
~~~

Unit Test: https://github.com/haoch/siddhi/blob/ce5ffcf9368f63d8af2072c4666b8c3e938a93be/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/ExceptionHandlerTestCase.java#L148-L168
