### PR TITLE
Split Function for String extension 

### DIFF
--- a/modules/siddhi-extensions/string/src/main/java/org/wso2/siddhi/extension/string/SplitFunctionExtension.java
+++ b/modules/siddhi-extensions/string/src/main/java/org/wso2/siddhi/extension/string/SplitFunctionExtension.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.extension.string;
+
+import org.wso2.siddhi.core.config.ExecutionPlanContext;
+import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.ExecutionPlanValidationException;
+
+/**
+ * split(sourceText, splitCharacter, returnedOutputPosition)
+ * Splits the source String by splitCharacter and return the string in the index given by returnedOutputPosition​ ​
+ * Accept Type(s): (STRING, STRING, INT)
+ * Return Type(s): STRING
+ */
+public class SplitFunctionExtension extends FunctionExecutor {
+
+    Attribute.Type returnType = Attribute.Type.STRING;
+
+    @Override
+    protected void init(ExpressionExecutor[] attributeExpressionExecutors, ExecutionPlanContext executionPlanContext) {
+        if (attributeExpressionExecutors.length != 3) {
+            throw new ExecutionPlanValidationException("Invalid no of arguments passed to str:split() function, " +
+                    "required 3, but found " + attributeExpressionExecutors.length);
+        }
+
+        if (attributeExpressionExecutors[0].getReturnType() != Attribute.Type.STRING) {
+            throw new ExecutionPlanValidationException("Invalid parameter type found for the first argument of str:split() function, " +
+                    "required " + Attribute.Type.STRING + ", but found " + attributeExpressionExecutors[0].getReturnType().toString());
+        }
+
+
+        if (attributeExpressionExecutors[1].getReturnType() != Attribute.Type.STRING) {
+            throw new ExecutionPlanValidationException("Invalid parameter type found for the second argument of str:split() function, " +
+                    "required " + Attribute.Type.STRING + ", but found " + attributeExpressionExecutors[1].getReturnType().toString());
+        }
+
+        if (attributeExpressionExecutors[2].getReturnType() != Attribute.Type.INT) {
+            throw new ExecutionPlanValidationException("Invalid parameter type found for the second argument of str:split() function, " +
+                    "required " + Attribute.Type.INT + ", but found " + attributeExpressionExecutors[2].getReturnType().toString());
+        }
+
+    }
+
+    @Override
+    protected Object execute(Object[] data) {
+        if (data[0] == null) {
+            throw new ExecutionPlanRuntimeException("Invalid input given to str:split() function. First argument cannot be null");
+        }
+        if (data[1] == null) {
+            throw new ExecutionPlanRuntimeException("Invalid input given to str:split() function. Second argument cannot be null");
+        }
+        if (data[2] == null) {
+            throw new ExecutionPlanRuntimeException("Invalid input given to str:split() function. Third argument cannot be null");
+        }
+        String source = (String) data[0];
+        String regex = (String) data[1];
+        int index = (Integer) data[2];
+        String splitStrArray[] = source.split(regex);
+        try {
+            return splitStrArray[index];
+        } catch (IndexOutOfBoundsException e) {
+            throw new ExecutionPlanRuntimeException("Index argument " + index + " is negative or not less than the length of the given string " + source, e);
+            //Runtime Exception was captured to avoid checking whether index < splitStrArray.length for performance reasons.​
+        }
+    }
+
+    @Override
+    protected Object execute(Object data) {
+        return null;  //Since the split function takes in 3 parameters, this method does not get called. Hence, not implemented.
+    }
+
+    @Override
+    public void start() {
+        //Nothing to start.
+    }
+
+    @Override
+    public void stop() {
+        //Nothing to stop.
+    }
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return returnType;
+    }
+
+    @Override
+    public Object[] currentState() {
+        return null;    //No need to maintain a state.
+    }
+
+    @Override
+    public void restoreState(Object[] state) {
+        //Since there's no need to maintain a state, nothing needs to be done here.
+    }
+}

--- a/modules/siddhi-extensions/string/src/main/java/org/wso2/siddhi/extension/string/SplitFunctionExtension.java
+++ b/modules/siddhi-extensions/string/src/main/java/org/wso2/siddhi/extension/string/SplitFunctionExtension.java
@@ -33,7 +33,7 @@ import org.wso2.siddhi.query.api.exception.ExecutionPlanValidationException;
  */
 public class SplitFunctionExtension extends FunctionExecutor {
 
-    Attribute.Type returnType = Attribute.Type.STRING;
+    private Attribute.Type returnType = Attribute.Type.STRING;
 
     @Override
     protected void init(ExpressionExecutor[] attributeExpressionExecutors, ExecutionPlanContext executionPlanContext) {

--- a/modules/siddhi-extensions/string/src/main/resources/str.siddhiext
+++ b/modules/siddhi-extensions/string/src/main/resources/str.siddhiext
@@ -34,3 +34,4 @@ hex=org.wso2.siddhi.extension.string.HexFunctionExtension
 unhex=org.wso2.siddhi.extension.string.UnhexFunctionExtension
 contains=org.wso2.siddhi.extension.string.ContainsFunctionExtension
 equalsIgnoreCase=org.wso2.siddhi.extension.string.EqualsIgnoreCaseFunctionExtension
+split=org.wso2.siddhi.extension.string.SplitFunctionExtension

--- a/modules/siddhi-extensions/string/src/test/java/org/wso2/siddhi/extension/string/SplitFunctionExtensionTestCase.java
+++ b/modules/siddhi-extensions/string/src/test/java/org/wso2/siddhi/extension/string/SplitFunctionExtensionTestCase.java
@@ -1,0 +1,135 @@
+package org.wso2.siddhi.extension.string;/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.Assert;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.ExecutionPlanRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.extension.string.test.util.SiddhiTestHelper;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SplitFunctionExtensionTestCase {
+
+    static final Logger log = Logger.getLogger(SplitFunctionExtension.class);
+    private AtomicInteger count = new AtomicInteger(0);
+    private volatile boolean eventArrived;
+
+    @Before
+    public void init() {
+        count.set(0);
+        eventArrived = false;
+    }
+
+    @Test
+    public void testSplitFunctionExtension() throws InterruptedException {
+        log.info("SplitFunctionExtensionTestCase TestCase");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "@config(async = 'true')define stream inputStream (symbol string, price long, " +
+                "volume long);";
+        String query = ("@info(name = 'query1') " + "from inputStream " + "select symbol , str:split(symbol, '_', 1) as splitText " +
+                "insert into outputStream;");
+        ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(inStreamDefinition + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        Assert.assertEquals("IBM", event.getData(1));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        Assert.assertEquals("WSO2", event.getData(1));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        Assert.assertEquals("XYZ", event.getData(1));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+        inputHandler.send(new Object[]{"Prod_IBM", 700f, 100l});
+        inputHandler.send(new Object[]{"Prod_WSO2_", 60.5f, 200l});
+        inputHandler.send(new Object[]{"Prod_XYZ", 60.5f, 200l});
+        SiddhiTestHelper.waitForEvents(500, 3, count, 60000);
+        Assert.assertEquals(3, count.get());
+        Assert.assertTrue(eventArrived);
+        executionPlanRuntime.shutdown();
+    }
+
+    @Test
+    public void testSplitFunctionExtension2() throws InterruptedException {
+        log.info("SplitFunctionExtensionTestCase TestCase, where both splitCharacter and index are variables.");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "@config(async = 'true')define stream inputStream (symbol string, splitCharacter string, index int);";
+
+        String query = (
+                "@info(name = 'query1') from inputStream select symbol , str:split(symbol, splitCharacter, index) as splitText " +
+                        "insert into outputStream;"
+        );
+
+        ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(inStreamDefinition + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        Assert.assertEquals("DELL", event.getData(1));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        Assert.assertEquals("CEP", event.getData(1));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        Assert.assertEquals("SIDDHI engine", event.getData(1));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+        inputHandler.send(new Object[]{"DELL/IBM/HP/", "/", 0});
+        inputHandler.send(new Object[]{"WSO2 CEP and IS", " ", 1});
+        inputHandler.send(new Object[]{"WSO2_CEP_SIDDHI engine", "_", 2});
+        SiddhiTestHelper.waitForEvents(500, 3, count, 60000);
+        Assert.assertEquals(3, count.get());
+        Assert.assertTrue(eventArrived);
+        executionPlanRuntime.shutdown();
+    }
+}

--- a/modules/siddhi-extensions/string/src/test/java/org/wso2/siddhi/extension/string/SplitFunctionExtensionTestCase.java
+++ b/modules/siddhi-extensions/string/src/test/java/org/wso2/siddhi/extension/string/SplitFunctionExtensionTestCase.java
@@ -1,4 +1,4 @@
-package org.wso2.siddhi.extension.string;/*
+/*
  * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
@@ -15,6 +15,7 @@ package org.wso2.siddhi.extension.string;/*
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.wso2.siddhi.extension.string;
 
 import junit.framework.Assert;
 import org.apache.log4j.Logger;
@@ -32,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class SplitFunctionExtensionTestCase {
 
-    static final Logger log = Logger.getLogger(SplitFunctionExtension.class);
+    private static final Logger log = Logger.getLogger(SplitFunctionExtensionTestCase.class);
     private AtomicInteger count = new AtomicInteger(0);
     private volatile boolean eventArrived;
 


### PR DESCRIPTION
This can be used as follows in Siddhi:
str:split(sourceString, splitCharacter, returnedOutputPosition)

This will split the sourceString by splitCharacter and return the string in the index given by returnedOutputPosition​ ​
 