### PR TITLE
Fixed `IS NULL` syntax in RDBMS

### DIFF
--- a/modules/siddhi-extensions/event-table/src/main/java/org/wso2/siddhi/extension/eventtable/rdbms/RDBMSEventTableConstants.java
+++ b/modules/siddhi-extensions/event-table/src/main/java/org/wso2/siddhi/extension/eventtable/rdbms/RDBMSEventTableConstants.java
@@ -52,6 +52,8 @@ public interface RDBMSEventTableConstants {
     public static final String EVENT_TABLE_GENERIC_RDBMS_LIMIT_SELECT_TABLE = "limitSelectRow";
     public static final String EVENT_TABLE_GENERIC_RDBMS_TABLE_ROW_EXIST = "isTableRowExist";
     public static final String EVENT_TABLE_CONDITION_WHITE_SPACE_CHARACTER = " ";
+    public static final String EVENT_TABLE_GENERIC_RDBMS_IS_NULL = "isNull";
+    public static final String EVENT_TABLE_GENERIC_RDBMS_NOT = "not";
 
     public static final String ANNOTATION_ELEMENT_DATASOURCE_NAME = "datasource.name";
     public static final String ANNOTATION_ELEMENT_TABLE_NAME = "table.name";

--- a/modules/siddhi-extensions/event-table/src/main/resources/rdbms-table-config.xml
+++ b/modules/siddhi-extensions/event-table/src/main/resources/rdbms-table-config.xml
@@ -62,6 +62,8 @@
                 <element key="notEqual">!=</element>
                 <element key="and">AND</element>
                 <element key="or">OR</element>
+                <element key="not">NOT</element>
+                <element key="isNull">IS NULL</element>
             </elements>
         </mapping>
         <mapping db='mysql'>


### PR DESCRIPTION
- Added `IS NULL` support for RDBMS tables
- Added `NOT` operator support for RDBMS tables (i.e. `NOT(value==20)`, `NOT IS NULL`)