### PR TITLE
External time sliding window does not remove expired events

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/ExternalTimeWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/ExternalTimeWindowProcessor.java
@@ -97,6 +97,9 @@ public class ExternalTimeWindowProcessor extends WindowProcessor implements Find
                 StreamEvent clonedEvent = streamEventCloner.copyStreamEvent(streamEvent);
                 clonedEvent.setType(StreamEvent.Type.EXPIRED);
 
+                // reset expiredEventChunk to make sure all of the expired events get removed,
+                // otherwise lastReturned.next will always return null and here while check is always false
+                expiredEventChunk.reset();
                 while (expiredEventChunk.hasNext()) {
                     StreamEvent expiredEvent = expiredEventChunk.next();
                     long expiredEventTime = (Long) timeStampVariableExpressionExecutor.execute(expiredEvent);


### PR DESCRIPTION
You can only see AttributeAggregator.processAdd but not AttributeAggregator.processRemove in external time sliding window. The issue is caused by we don't reset expiredEventChunk before removing expired events, and the lastReturned event does not have next event.