### PR TITLE
High availability in a multi-node Siddhi deployment

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/ExecutionPlanRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/ExecutionPlanRuntime.java
@@ -31,6 +31,7 @@ import org.wso2.siddhi.core.query.input.stream.single.SingleStreamRuntime;
 import org.wso2.siddhi.core.query.output.callback.InsertIntoStreamCallback;
 import org.wso2.siddhi.core.query.output.callback.QueryCallback;
 import org.wso2.siddhi.core.stream.StreamJunction;
+import org.wso2.siddhi.core.stream.input.InputEventHandler;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.input.InputManager;
 import org.wso2.siddhi.core.stream.input.source.Source;
@@ -120,7 +121,7 @@ public class ExecutionPlanRuntime {
         for (Map.Entry<String, List<Source>> sourceEntries : eventSourceMap.entrySet()) {
             InputHandler inputHandler = getInputHandler(sourceEntries.getKey());
             for (Source source : sourceEntries.getValue()) {
-                source.getMapper().setInputHandler(inputHandler);
+                source.getMapper().setInputHandler(new InputEventHandler(inputHandler));
             }
         }
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/ExecutionPlanRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/ExecutionPlanRuntime.java
@@ -121,7 +121,7 @@ public class ExecutionPlanRuntime {
         for (Map.Entry<String, List<Source>> sourceEntries : eventSourceMap.entrySet()) {
             InputHandler inputHandler = getInputHandler(sourceEntries.getKey());
             for (Source source : sourceEntries.getValue()) {
-                source.getMapper().setInputHandler(new InputEventHandler(inputHandler));
+                source.getMapper().setInputEventHandler(new InputEventHandler(inputHandler, executionPlanContext));
             }
         }
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/Event.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/Event.java
@@ -82,6 +82,7 @@ public class Event {
     public String toString() {
         return "Event{" +
                 "timestamp=" + timestamp +
+                ", id=" + id +
                 ", data=" + Arrays.toString(data) +
                 ", isExpired=" + isExpired +
                 '}';

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/InputEventHandler.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/InputEventHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.stream.input;
+
+import org.wso2.siddhi.core.event.Event;
+
+/**
+ * This class wraps {@link InputHandler} class in order to guarantee exactly once processing
+ */
+public class InputEventHandler {
+
+    private InputHandler inputHandler;
+
+    public InputEventHandler(InputHandler inputHandler) {
+        this.inputHandler = inputHandler;
+    }
+
+    public Long sendEvent(Event event, Long lastEventId) throws InterruptedException {
+        long eventId = event.getId();
+        // event id -1 is reserved for the events that are arriving for the first Siddhi node
+        if (lastEventId == null || eventId == -1 || lastEventId < eventId) {
+            inputHandler.send(event);
+            return eventId;
+        }
+        return lastEventId;
+    }
+
+    public Long sendEvents(Event[] events, Long lastEventId) throws InterruptedException {
+        for (Event event : events) {
+            long eventId = event.getId();
+            // event id -1 is reserved for the events that are arriving for the first Siddhi node
+            if (lastEventId == null || eventId == -1 || lastEventId < eventId) {
+                lastEventId = eventId;
+            }
+        }
+        inputHandler.send(events);
+        return lastEventId;
+    }
+
+    public InputHandler getInputHandler() {
+        return inputHandler;
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/PassThroughSourceMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/PassThroughSourceMapper.java
@@ -22,7 +22,6 @@ import org.apache.log4j.Logger;
 import org.wso2.siddhi.annotation.Extension;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
-import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.AttributeMapping;
 import org.wso2.siddhi.core.util.config.ConfigReader;
 import org.wso2.siddhi.core.util.transport.OptionHolder;
@@ -44,14 +43,14 @@ public class PassThroughSourceMapper extends SourceMapper {
     }
 
     @Override
-    protected void mapAndProcess(Object eventObject, InputHandler inputHandler) throws InterruptedException {
+    protected void mapAndProcess(Object eventObject) throws InterruptedException {
         if (eventObject != null) {
             if (eventObject instanceof Event[]) {
-                inputHandler.send((Event[]) eventObject);
+                send((Event[]) eventObject);
             } else if (eventObject instanceof Event) {
-                inputHandler.send((Event) eventObject);
+                send((Event) eventObject);
             } else if (eventObject instanceof Object[]) {
-                inputHandler.send((Object[]) eventObject);
+                send((Object[]) eventObject);
             } else {
                 throw new ExecutionPlanRuntimeException("Event object must be either Event[], Event or Object[] " +
                         "but found " + eventObject.getClass().getCanonicalName());

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/PassThroughSourceMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/PassThroughSourceMapper.java
@@ -23,6 +23,7 @@ import org.wso2.siddhi.annotation.Extension;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
 import org.wso2.siddhi.core.stream.AttributeMapping;
+import org.wso2.siddhi.core.stream.input.InputEventHandler;
 import org.wso2.siddhi.core.util.config.ConfigReader;
 import org.wso2.siddhi.core.util.transport.OptionHolder;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
@@ -43,14 +44,14 @@ public class PassThroughSourceMapper extends SourceMapper {
     }
 
     @Override
-    protected void mapAndProcess(Object eventObject) throws InterruptedException {
+    protected void mapAndProcess(Object eventObject, InputEventHandler inputEventHandler) throws InterruptedException {
         if (eventObject != null) {
             if (eventObject instanceof Event[]) {
-                send((Event[]) eventObject);
+                inputEventHandler.sendEvents((Event[]) eventObject);
             } else if (eventObject instanceof Event) {
-                send((Event) eventObject);
+                inputEventHandler.sendEvent((Event) eventObject);
             } else if (eventObject instanceof Object[]) {
-                send((Object[]) eventObject);
+                inputEventHandler.getInputHandler().send((Object[]) eventObject);
             } else {
                 throw new ExecutionPlanRuntimeException("Event object must be either Event[], Event or Object[] " +
                         "but found " + eventObject.getClass().getCanonicalName());

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceMapper.java
@@ -19,58 +19,47 @@
 package org.wso2.siddhi.core.stream.input.source;
 
 import org.apache.log4j.Logger;
-import org.wso2.siddhi.core.config.ExecutionPlanContext;
-import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.stream.AttributeMapping;
 import org.wso2.siddhi.core.stream.input.InputEventHandler;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.util.config.ConfigReader;
-import org.wso2.siddhi.core.util.snapshot.Snapshotable;
 import org.wso2.siddhi.core.util.transport.OptionHolder;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Convert custom input from {@link Source} to {@link org.wso2.siddhi.core.event.ComplexEventChunk}.
  */
-public abstract class SourceMapper implements SourceEventListener, Snapshotable {
+public abstract class SourceMapper implements SourceEventListener {
 
-    private InputEventHandler inputHandler;
+    private InputEventHandler inputEventHandler;
     private StreamDefinition streamDefinition;
     private String mapType;
-    private String elementId;
-    /**
-     * {@link Event#id} of the last event which is processed by this mapper
-     */
-    private Long lastEventId = null;
     private static final Logger log = Logger.getLogger(SourceMapper.class);
 
     public void init(StreamDefinition streamDefinition, String mapType, OptionHolder mapOptionHolder,
-                     List<AttributeMapping> attributeMappings, ConfigReader configReader, ExecutionPlanContext
-                             executionPlanContext) {
+                     List<AttributeMapping> attributeMappings, ConfigReader configReader) {
         this.streamDefinition = streamDefinition;
         this.mapType = mapType;
-        this.elementId = executionPlanContext.getElementIdGenerator().createNewId();
         init(streamDefinition, mapOptionHolder, attributeMappings, configReader);
     }
 
-    public abstract void init(StreamDefinition streamDefinition, OptionHolder optionHolder, List<AttributeMapping> attributeMappingList, ConfigReader configReader);
+    public abstract void init(StreamDefinition streamDefinition, OptionHolder optionHolder, List<AttributeMapping>
+            attributeMappingList, ConfigReader configReader);
 
-    public void setInputHandler(InputEventHandler inputHandler) {
-        this.inputHandler = inputHandler;
+    public void setInputEventHandler(InputEventHandler inputEventHandler) {
+        this.inputEventHandler = inputEventHandler;
     }
 
     public InputHandler getInputHandler() {
-        return inputHandler.getInputHandler();
+        return inputEventHandler.getInputHandler();
     }
 
     public void onEvent(Object eventObject) {
         try {
             if (eventObject != null) {
-                mapAndProcess(eventObject);
+                mapAndProcess(eventObject, inputEventHandler);
             }
         } catch (InterruptedException e) {
             log.error("Error while processing '" + eventObject + "', for the input Mapping '" + mapType +
@@ -78,45 +67,10 @@ public abstract class SourceMapper implements SourceEventListener, Snapshotable 
         }
     }
 
-    public void send(Event event) throws InterruptedException {
-        lastEventId = inputHandler.sendEvent(event, getLastEventId());
-    }
-
-    public void send(Event[] events) throws InterruptedException {
-        lastEventId = inputHandler.sendEvents(events, getLastEventId());
-    }
-
-    public void send(Object[] objects) throws InterruptedException {
-        inputHandler.getInputHandler().send(objects);
-    }
-
-    public Long getLastEventId() {
-        return lastEventId;
-    }
-
-    @Override
-    public Map<String, Object> currentState() {
-        Map<String, Object> state = new HashMap<>();
-        synchronized (lastEventId) {
-            state.put("LastEventId", lastEventId);
-        }
-        return state;
-    }
-
-    @Override
-    public void restoreState(Map<String, Object> state) {
-        lastEventId = (Long) state.get("LastEventId");
-    }
-
-    @Override
-    public String getElementId() {
-        return elementId;
-    }
-
     public StreamDefinition getStreamDefinition() {
         return streamDefinition;
     }
 
-    protected abstract void mapAndProcess(Object eventObject) throws InterruptedException;
-
+    protected abstract void mapAndProcess(Object eventObject, InputEventHandler inputEventHandler) throws
+            InterruptedException;
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/PassThroughSinkMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/PassThroughSinkMapper.java
@@ -47,14 +47,12 @@ public class PassThroughSinkMapper extends SinkMapper {
     @Override
     public void mapAndSend(Event[] events, OptionHolder optionHolder, TemplateBuilder payloadTemplateBuilder,
                            SinkListener sinkListener, DynamicOptions dynamicOptions) throws ConnectionUnavailableException {
-        updateEventIds(events);
         sinkListener.publish(events, dynamicOptions);
     }
 
     @Override
     public void mapAndSend(Event event, OptionHolder optionHolder, TemplateBuilder payloadTemplateBuilder,
                            SinkListener sinkListener, DynamicOptions dynamicOptions) throws ConnectionUnavailableException {
-        updateEventId(event);
         sinkListener.publish(event, dynamicOptions);
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkMapper.java
@@ -24,7 +24,6 @@ import org.wso2.siddhi.core.exception.ConnectionUnavailableException;
 import org.wso2.siddhi.core.util.config.ConfigReader;
 import org.wso2.siddhi.core.util.snapshot.Snapshotable;
 import org.wso2.siddhi.core.util.transport.DynamicOptions;
-import org.wso2.siddhi.core.util.transport.Option;
 import org.wso2.siddhi.core.util.transport.OptionHolder;
 import org.wso2.siddhi.core.util.transport.TemplateBuilder;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
@@ -37,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class SinkMapper implements Snapshotable {
     private String type;
-    private AtomicLong lastEventId = new AtomicLong(0);
+    private AtomicLong lastEventId = new AtomicLong(Long.MIN_VALUE);
     private String elementId;
     private OptionHolder optionHolder;
     private TemplateBuilder payloadTemplateBuilder = null;
@@ -64,7 +63,8 @@ public abstract class SinkMapper implements Snapshotable {
      * @param event event to be updated
      */
     public void updateEventId(Event event) {
-        event.setId(lastEventId.incrementAndGet());
+        // event id -1 is reserved for the events that are arriving for the first Siddhi node
+        event.setId(lastEventId.incrementAndGet() == -1 ? lastEventId.incrementAndGet() : lastEventId.get());
     }
 
     /**
@@ -74,7 +74,8 @@ public abstract class SinkMapper implements Snapshotable {
      */
     public void updateEventIds(Event[] events) {
         for (Event event : events) {
-            event.setId(lastEventId.incrementAndGet());
+            // event id -1 is reserved for the events that are arriving for the first Siddhi node
+            event.setId(lastEventId.incrementAndGet() == -1 ? lastEventId.incrementAndGet() : lastEventId.get());
         }
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkMapper.java
@@ -62,7 +62,7 @@ public abstract class SinkMapper implements Snapshotable {
      *
      * @param event event to be updated
      */
-    public void updateEventId(Event event) {
+    private void updateEventId(Event event) {
         // event id -1 is reserved for the events that are arriving for the first Siddhi node
         event.setId(lastEventId.incrementAndGet() == -1 ? lastEventId.incrementAndGet() : lastEventId.get());
     }
@@ -72,7 +72,7 @@ public abstract class SinkMapper implements Snapshotable {
      *
      * @param events events to be updated
      */
-    public void updateEventIds(Event[] events) {
+    private void updateEventIds(Event[] events) {
         for (Event event : events) {
             // event id -1 is reserved for the events that are arriving for the first Siddhi node
             event.setId(lastEventId.incrementAndGet() == -1 ? lastEventId.incrementAndGet() : lastEventId.get());
@@ -107,7 +107,7 @@ public abstract class SinkMapper implements Snapshotable {
      */
     public void mapAndSend(Event[] events, SinkListener sinkListener)
             throws ConnectionUnavailableException {
-
+        updateEventIds(events);
         if (groupDeterminer != null) {
             LinkedHashMap<String, ArrayList<Event>> eventMap = new LinkedHashMap<>();
             for (Event event : events) {
@@ -136,6 +136,7 @@ public abstract class SinkMapper implements Snapshotable {
      */
     public void mapAndSend(Event event, SinkListener sinkListener)
             throws ConnectionUnavailableException {
+        updateEventId(event);
         mapAndSend(event, optionHolder, payloadTemplateBuilder, sinkListener, new DynamicOptions(event));
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -293,7 +293,7 @@ public class DefinitionParserHelper {
 
                     sourceMapper.init(streamDefinition, mapType, mapOptionHolder, getAttributeMappings(mapAnnotation),
                             executionPlanContext.getSiddhiContext().getConfigManager().generateConfigReader
-                                    (mapperExtension.getNamespace(), mapperExtension.getName()), executionPlanContext);
+                                    (mapperExtension.getNamespace(), mapperExtension.getName()));
                     source.init(sourceOptionHolder, sourceMapper, executionPlanContext.getSiddhiContext()
                             .getConfigManager().generateConfigReader
                                     (sourceExtension.getNamespace(), sourceExtension.getName()), executionPlanContext);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -293,7 +293,7 @@ public class DefinitionParserHelper {
 
                     sourceMapper.init(streamDefinition, mapType, mapOptionHolder, getAttributeMappings(mapAnnotation),
                             executionPlanContext.getSiddhiContext().getConfigManager().generateConfigReader
-                                    (mapperExtension.getNamespace(), mapperExtension.getName()));
+                                    (mapperExtension.getNamespace(), mapperExtension.getName()), executionPlanContext);
                     source.init(sourceOptionHolder, sourceMapper, executionPlanContext.getSiddhiContext()
                             .getConfigManager().generateConfigReader
                                     (sourceExtension.getNamespace(), sourceExtension.getName()), executionPlanContext);

--- a/modules/siddhi-extensions/input-mappers/text-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/text/TextSourceMapper.java
+++ b/modules/siddhi-extensions/input-mappers/text-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/text/TextSourceMapper.java
@@ -23,11 +23,10 @@ import org.wso2.siddhi.core.event.ComplexEventChunk;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
 import org.wso2.siddhi.core.query.output.callback.OutputCallback;
-import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.stream.AttributeMapping;
 import org.wso2.siddhi.core.stream.input.source.Source;
 import org.wso2.siddhi.core.stream.input.source.SourceMapper;
 import org.wso2.siddhi.core.util.AttributeConverter;
-import org.wso2.siddhi.core.stream.AttributeMapping;
 import org.wso2.siddhi.core.util.config.ConfigReader;
 import org.wso2.siddhi.core.util.transport.OptionHolder;
 import org.wso2.siddhi.query.api.definition.Attribute;
@@ -135,20 +134,13 @@ public class TextSourceMapper extends SourceMapper {
      * {@link OutputCallback}.
      *
      * @param eventObject  the TEXT string
-     * @param inputHandler input handler
      */
     @Override
-    protected void mapAndProcess(Object eventObject, InputHandler inputHandler) throws InterruptedException {
+    protected void mapAndProcess(Object eventObject) throws InterruptedException {
         if (eventObject != null) {
             synchronized (this) {
                 Event event = convertToEvent(eventObject);
-                long eventId = event.getId();
-                // event id -1 is reserved for the events that are arriving for the first Siddhi node
-                if (getLastEventId() == null || eventId == -1 || getLastEventId() < eventId) {
-                    setLastEventId(eventId);
-                    inputHandler.send(event);
-                }
-
+                send(event);
             }
         }
     }

--- a/modules/siddhi-extensions/input-mappers/text-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/text/TextSourceMapper.java
+++ b/modules/siddhi-extensions/input-mappers/text-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/text/TextSourceMapper.java
@@ -24,6 +24,7 @@ import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
 import org.wso2.siddhi.core.query.output.callback.OutputCallback;
 import org.wso2.siddhi.core.stream.AttributeMapping;
+import org.wso2.siddhi.core.stream.input.InputEventHandler;
 import org.wso2.siddhi.core.stream.input.source.Source;
 import org.wso2.siddhi.core.stream.input.source.SourceMapper;
 import org.wso2.siddhi.core.util.AttributeConverter;
@@ -136,11 +137,11 @@ public class TextSourceMapper extends SourceMapper {
      * @param eventObject  the TEXT string
      */
     @Override
-    protected void mapAndProcess(Object eventObject) throws InterruptedException {
+    protected void mapAndProcess(Object eventObject, InputEventHandler inputEventHandler) throws InterruptedException {
         if (eventObject != null) {
             synchronized (this) {
                 Event event = convertToEvent(eventObject);
-                send(event);
+                inputEventHandler.sendEvent(event);
             }
         }
     }

--- a/modules/siddhi-extensions/input-mappers/xml-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/xml/XmlSourceMapper.java
+++ b/modules/siddhi-extensions/input-mappers/xml-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/xml/XmlSourceMapper.java
@@ -30,6 +30,7 @@ import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
 import org.wso2.siddhi.core.query.output.callback.OutputCallback;
 import org.wso2.siddhi.core.stream.AttributeMapping;
+import org.wso2.siddhi.core.stream.input.InputEventHandler;
 import org.wso2.siddhi.core.stream.input.source.Source;
 import org.wso2.siddhi.core.stream.input.source.SourceMapper;
 import org.wso2.siddhi.core.util.AttributeConverter;
@@ -167,12 +168,12 @@ public class XmlSourceMapper extends SourceMapper {
      * @param eventObject  the input event, given as an XML string
      */
     @Override
-    protected void mapAndProcess(Object eventObject) throws InterruptedException {
+    protected void mapAndProcess(Object eventObject, InputEventHandler inputEventHandler) throws InterruptedException {
         Event[] result;
         try {
             result = convertToEvents(eventObject);
             if (result.length > 0) {
-                send(result);
+                inputEventHandler.sendEvents(result);
             }
         } catch (Throwable t) { //stringToOM does not throw the exception immediately due to streaming. Hence need this.
             log.error("Exception occurred when converting XML message to Siddhi Event", t);

--- a/modules/siddhi-extensions/input-mappers/xml-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/xml/XmlSourceMapper.java
+++ b/modules/siddhi-extensions/input-mappers/xml-input-mapper/src/main/java/org/wso2/siddhi/extension/input/mapper/xml/XmlSourceMapper.java
@@ -30,7 +30,6 @@ import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.ExecutionPlanRuntimeException;
 import org.wso2.siddhi.core.query.output.callback.OutputCallback;
 import org.wso2.siddhi.core.stream.AttributeMapping;
-import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.input.source.Source;
 import org.wso2.siddhi.core.stream.input.source.SourceMapper;
 import org.wso2.siddhi.core.util.AttributeConverter;
@@ -40,13 +39,13 @@ import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 import org.wso2.siddhi.query.api.exception.ExecutionPlanValidationException;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
 
 /**
  * This mapper converts XML string input to {@link ComplexEventChunk}. This extension accepts optional xpath expressions to
@@ -166,15 +165,14 @@ public class XmlSourceMapper extends SourceMapper {
      * and send to the {@link OutputCallback}.
      *
      * @param eventObject  the input event, given as an XML string
-     * @param inputHandler input handler
      */
     @Override
-    protected void mapAndProcess(Object eventObject, InputHandler inputHandler) throws InterruptedException {
+    protected void mapAndProcess(Object eventObject) throws InterruptedException {
         Event[] result;
         try {
             result = convertToEvents(eventObject);
             if (result.length > 0) {
-                inputHandler.send(result);
+                send(result);
             }
         } catch (Throwable t) { //stringToOM does not throw the exception immediately due to streaming. Hence need this.
             log.error("Exception occurred when converting XML message to Siddhi Event", t);

--- a/modules/siddhi-extensions/input-transports/kafka-input-transport/src/main/java/org/wso2/siddhi/extension/input/transport/kafka/KafkaConsumerThread.java
+++ b/modules/siddhi-extensions/input-transports/kafka-input-transport/src/main/java/org/wso2/siddhi/extension/input/transport/kafka/KafkaConsumerThread.java
@@ -92,7 +92,8 @@ public class KafkaConsumerThread implements Runnable {
                     for (Map.Entry<Integer, Long> entry : offsetMap.entrySet()) {
                         TopicPartition partition = new TopicPartition(topic, entry.getKey());
                         if (partitionsList.contains(partition)) {
-                            log.info("Seeking partition: " + partition + " for topic: " + topic);
+                            log.info("Seeking partition: " + partition + " for topic: " + topic + " offset: " + (entry
+                                    .getValue() + 1));
                             try {
                                 consumerLock.lock();
                                 consumer.seek(partition, entry.getValue() + 1);

--- a/modules/siddhi-extensions/output-mappers/text-output-mapper/src/main/java/org/wso2/siddhi/extension/output/mapper/text/TextSinkMapper.java
+++ b/modules/siddhi-extensions/output-mappers/text-output-mapper/src/main/java/org/wso2/siddhi/extension/output/mapper/text/TextSinkMapper.java
@@ -95,14 +95,13 @@ public class TextSinkMapper extends SinkMapper {
      */
     private Object constructDefaultMapping(Event event) {
         StringBuilder eventText = new StringBuilder();
+        eventText.append("siddhiEventId").append(EVENT_ATTRIBUTE_VALUE_SEPARATOR).append(event.getId()).append("\n");
         Object[] data = event.getData();
         for (int i = 0; i < data.length; i++) {
-            String attributeName = streamDefinition.getAttributeNameArray()[i];
             Object attributeValue = data[i];
-            eventText.append(attributeName).append(EVENT_ATTRIBUTE_VALUE_SEPARATOR).append(attributeValue.toString()).append(EVENT_ATTRIBUTE_SEPARATOR).append("\n");
+            eventText.append(attributeValue.toString()).append(EVENT_ATTRIBUTE_SEPARATOR);
         }
         eventText.deleteCharAt(eventText.lastIndexOf(EVENT_ATTRIBUTE_SEPARATOR));
-        eventText.deleteCharAt(eventText.lastIndexOf("\n"));
 
 //        // Get arbitrary data from event
 //        Map<String, Object> arbitraryDataMap = event.getArbitraryDataMap();

--- a/modules/siddhi-extensions/output-mappers/text-output-mapper/src/main/java/org/wso2/siddhi/extension/output/mapper/text/TextSinkMapper.java
+++ b/modules/siddhi-extensions/output-mappers/text-output-mapper/src/main/java/org/wso2/siddhi/extension/output/mapper/text/TextSinkMapper.java
@@ -63,7 +63,6 @@ public class TextSinkMapper extends SinkMapper {
     public void mapAndSend(Event[] events, OptionHolder optionHolder, TemplateBuilder payloadTemplateBuilder,
                            SinkListener sinkListener, DynamicOptions dynamicOptions)
             throws ConnectionUnavailableException {
-        updateEventIds(events);
         if (this.payloadTemplateBuilder != null) {
             for (Event event : events) {
                 sinkListener.publish(payloadTemplateBuilder.build(event), dynamicOptions);
@@ -79,7 +78,6 @@ public class TextSinkMapper extends SinkMapper {
     public void mapAndSend(Event event, OptionHolder optionHolder, TemplateBuilder payloadTemplateBuilder,
                            SinkListener sinkListener, DynamicOptions dynamicOptions)
             throws ConnectionUnavailableException {
-        updateEventId(event);
         if (this.payloadTemplateBuilder != null) {
             sinkListener.publish(payloadTemplateBuilder.build(event), dynamicOptions);
         } else {

--- a/modules/siddhi-extensions/output-transports/kafka-output-transport/src/main/java/org/wso2/siddhi/extension/output/transport/kafka/KafkaSink.java
+++ b/modules/siddhi-extensions/output-transports/kafka-output-transport/src/main/java/org/wso2/siddhi/extension/output/transport/kafka/KafkaSink.java
@@ -141,30 +141,4 @@ public class KafkaSink extends Sink {
     public void restoreState(Map<String, Object> state) {
 
     }
-
-    private class KafkaSender implements Runnable {
-
-        String topic;
-        Object message;
-        String partitionNo;
-
-        KafkaSender(String topic, String partitionNo, Object message) {
-            this.topic = topic;
-            this.message = message;
-            this.partitionNo = partitionNo;
-        }
-
-        @Override
-        public void run() {
-            try {
-                if(null == partitionNo) {
-                    producer.send(new ProducerRecord<>(topic, message.toString()));
-                } else {
-                    producer.send(new ProducerRecord<>(topic, partitionNo, message.toString()));
-                }
-            } catch (Throwable e) {
-                log.error("Unexpected error when sending event via Kafka Output Adapter:" + e.getMessage(), e);
-            }
-        }
-    }
 }

--- a/modules/siddhi-extensions/output-transports/kafka-output-transport/src/main/java/org/wso2/siddhi/extension/output/transport/kafka/KafkaSink.java
+++ b/modules/siddhi-extensions/output-transports/kafka-output-transport/src/main/java/org/wso2/siddhi/extension/output/transport/kafka/KafkaSink.java
@@ -18,8 +18,8 @@
 
 package org.wso2.siddhi.extension.output.transport.kafka;
 
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.annotation.Extension;
@@ -34,7 +34,6 @@ import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
 @Extension(
@@ -104,9 +103,14 @@ public class KafkaSink extends Sink {
         String topic = topicOption.getValue(transportOptions);
         String partitionNo = partitionOption.getValue(transportOptions);
         try {
-            executorService.submit(new KafkaSender(topic, partitionNo, payload));
-        } catch (RejectedExecutionException e) {
-            log.error("Job queue is full : " + e.getMessage(), e);
+            if (null == partitionNo) {
+                producer.send(new ProducerRecord<>(topic, payload.toString()));
+            } else {
+                producer.send(new ProducerRecord<>(topic, partitionNo, payload.toString()));
+            }
+        } catch (Exception e) {
+            log.error(String.format("Failed to publish the message to [topic] %s [partition-no] %s. Error: %s",
+                    topic, partitionNo, e.getMessage()), e);
         }
     }
 


### PR DESCRIPTION
This commit implements the high availability for a multi-node Siddhi deployment
using Kafka transport as the communication medium between nodes.

eg:
kafka -> Siddhi1 -> kafka -> Siddhi2 -> output

Feature is tested using a test case, which creates above shown scenario
and executes a siddhi file in a distributed manner (1 query is deployed
in Siddhi1 and the other query is deployed in Siddhi2).