### PR TITLE
Fix for ScriptFunctionExecutor to enable cloning

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/executor/function/FunctionExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/executor/function/FunctionExecutor.java
@@ -37,6 +37,7 @@ public abstract class FunctionExecutor implements ExpressionExecutor, EternalRef
     protected ExpressionExecutor[] attributeExpressionExecutors;
     protected ExecutionPlanContext executionPlanContext;
     protected String elementId;
+    protected String functionId;
     protected String queryName;
     private ConfigReader configReader;
     private int attributeSize;
@@ -69,6 +70,7 @@ public abstract class FunctionExecutor implements ExpressionExecutor, EternalRef
                 innerExpressionExecutors[i] = attributeExpressionExecutors[i].cloneExecutor(key);
             }
             functionExecutor.elementId = elementId + "-" + key;
+            functionExecutor.functionId = functionId;
             functionExecutor.initExecutor(innerExpressionExecutors, executionPlanContext, queryName, configReader);
             functionExecutor.start();
             return functionExecutor;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/executor/function/ScriptFunctionExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/executor/function/ScriptFunctionExecutor.java
@@ -35,7 +35,8 @@ public class ScriptFunctionExecutor extends FunctionExecutor {
     static final Logger LOG = Logger.getLogger(ScriptFunctionExecutor.class);
     Attribute.Type returnType;
     Script script;
-    private String functionId;
+
+    public ScriptFunctionExecutor() { }
 
     public ScriptFunctionExecutor(String name) {
         this.functionId = name;


### PR DESCRIPTION
This fixes a bug during a clone operation which is invoked during when processing data. Stack trace for the bug is below. Tested this with the fix and it works fine.

result = {StackTraceElement[30]@10489} 
 0 = {StackTraceElement@10253} "java.lang.Class.getConstructor0(Class.java:3082)"
 1 = {StackTraceElement@10254} "java.lang.Class.newInstance(Class.java:412)"
 2 = {StackTraceElement@10255} "org.wso2.siddhi.core.executor.function.FunctionExecutor.cloneExecutor(FunctionExecutor.java:56)"
 3 = {StackTraceElement@10256} "org.wso2.siddhi.core.query.selector.attribute.aggregator.AttributeAggregator.cloneAggregator(AttributeAggregator.java:58)"
 4 = {StackTraceElement@10257} "org.wso2.siddhi.core.query.selector.attribute.processor.executor.GroupByAggregationAttributeExecutor.execute(GroupByAggregationAttributeExecutor.java:51)"
 5 = {StackTraceElement@10258} "org.wso2.siddhi.core.query.selector.attribute.processor.AttributeProcessor.process(AttributeProcessor.java:38)"
 6 = {StackTraceElement@10259} "org.wso2.siddhi.core.query.selector.QuerySelector.processInBatchGroupBy(QuerySelector.java:225)"
 7 = {StackTraceElement@10260} "org.wso2.siddhi.core.query.selector.QuerySelector.process(QuerySelector.java:78)"