### PR TITLE
Bug Fix : Remove ".md" from template links

### DIFF
--- a/modules/siddhi-doc-gen/src/main/resources/templates/documentation.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/documentation.md.ftl
@@ -16,15 +16,15 @@
   ~ under the License.
   -->
 <#list metaData as namespace>
-# ${namespace.name?capitalize}
+## ${namespace.name?capitalize}
 
 <#list namespace.extensionMap as extensionType, extensionsList>
 <#list extensionsList as extension>
-## ${extension.name} _(${extensionType})_
+### ${extension.name} _(${extensionType})_
 
 <p style="word-wrap: break-word">${formatDescription(extension.description)}</p>
 
-### Syntax
+#### Syntax
 
 <#if ["Function", "Attribute Aggregator"]?seq_index_of(extensionType) != -1>
 ```
@@ -55,7 +55,7 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
 </#if>
 
 <#list extension.parameters>
-#### Query Parameters
+##### Query Parameters
 
 <table>
     <tr>
@@ -80,7 +80,7 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
 </#list>
 
 <#list extension.systemParameters>
-### System Parameters
+#### System Parameters
 
 <table>
     <tr>
@@ -102,7 +102,7 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
 
 <#if ["Stream Processor", "Stream Function"]?seq_index_of(extensionType) != -1>
 <#list extension.returnAttributes>
-### Extra Return Attributes
+#### Extra Return Attributes
 
 <table>
     <tr>
@@ -122,10 +122,10 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
 </#if>
 
 <#list extension.examples>
-### Examples
+#### Examples
 
 <#items as example>
-#### Example ${example?index + 1}
+##### Example ${example?index + 1}
 
 ```
 ${example.syntax}

--- a/modules/siddhi-doc-gen/src/main/resources/templates/extensions.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/extensions.md.ftl
@@ -8,7 +8,7 @@ Siddhi currently have several prewritten extensions as follows;
 <#list extensionRepositories>
 ### ${title}
 <#items as extensionRepository>
-1. <a target="_blank" href="https://github.com/${extensionsOwner}/${extensionRepository}/blob/master/docs/index.md">${extensionRepository?replace("^siddhi-gpl-", "", "rf")?replace("^siddhi-", "", "rf")?replace("-", " ")?capitalize}</a>
+1. <a target="_blank" href="https://${extensionsOwner}.github.io/${extensionRepository}">${extensionRepository?replace("^siddhi-gpl-", "", "rf")?replace("^siddhi-", "", "rf")?replace("-", " ")?capitalize}</a>
 </#items>
 </#list>
 

--- a/modules/siddhi-doc-gen/src/main/resources/templates/index.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/index.md.ftl
@@ -6,6 +6,6 @@ ${readMeFileLine}
 
 <#if documentationFiles??>
 <#list documentationFiles as documentationFile>
-1. <a href="./api/${documentationFile}">${documentationFile?remove_ending(".md")}</a>
+1. <a href="./api/${documentationFile?remove_ending(".md")}">${documentationFile?remove_ending(".md")}</a>
 </#list>
 </#if>


### PR DESCRIPTION
This PR contains the following
- Removing ".md" endings from urls
- Fixing the table of contents in documentation page