### PR TITLE
Doc Gen plugin - Update templates

### DIFF
--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
@@ -43,7 +43,7 @@ public class Constants {
     public static final String GITHUB_OWNER_WSO2_EXTENSIONS = "wso2-extensions";
 
     public static final String MKDOCS_CONFIG_PAGES_KEY = "pages";
-    public static final String MKDOCS_CONFIG_PAGES_API_KEY = "Api";
+    public static final String MKDOCS_CONFIG_PAGES_API_KEY = "API Docs";
     public static final String MKDOCS_FILE_SEPARATOR = "/";
 
     public static final String README_FILE_NAME = "README";

--- a/modules/siddhi-doc-gen/src/main/resources/templates/documentation.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/documentation.md.ftl
@@ -15,6 +15,8 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+# API Docs
+
 <#list metaData as namespace>
 ## ${namespace.name?capitalize}
 


### PR DESCRIPTION
This PR contains the following.

- Changing the top level heading of documentation page to "API Docs"
- Changing the mkdocs configuration file key to "API Docs"