### PR TITLE
Fix Regex bug in android

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -667,7 +667,7 @@ public class DefinitionParserHelper {
         Map<String, String> options = new HashMap<String, String>();
         Map<String, String> dynamicOptions = new HashMap<String, String>();
         for (Element element : annotation.getElements()) {
-            if (Pattern.matches("\\{\\{.*?}}", element.getValue())) {
+            if (Pattern.matches("\\{\\{.*?\\}\\}", element.getValue())) {
                 if (supportedDynamicOptionList.contains(element.getKey())) {
                     dynamicOptions.put(element.getKey(), element.getValue());
                 } else {


### PR DESCRIPTION
Siddhi extensions won't work in android platform.
The issue is that the regex engine used in Android is an ICU engine (http://userguide.icu-project.org/strings/regexp)  that is different from Java one, and both { and } that represent literal open/close curly braces must be escaped in ICU regex patterns.