### PR TITLE
adding fix to accept options as dynamic when placeholder placed within a stirng

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -677,7 +677,7 @@ public class DefinitionParserHelper {
         Map<String, String> options = new HashMap<String, String>();
         Map<String, String> dynamicOptions = new HashMap<String, String>();
         for (Element element : annotation.getElements()) {
-            if (Pattern.matches("\\{\\{.*?\\}\\}", element.getValue())) {
+            if (Pattern.matches("(.*?)\\{\\{.*?}}(.*?)", element.getValue())) {
                 if (supportedDynamicOptionList.contains(element.getKey())) {
                     dynamicOptions.put(element.getKey(), element.getValue());
                 } else {


### PR DESCRIPTION
Currently siddhi only identifies option parameter values defined only with a place holder. 
But it does not identifies option parameters as dynamic if the place holder is placed in the middle of a string.

For example :
`@sink(type='file', uri={{symbol}}'`
In this case, uri will be identified as a dynamic option.

`@sink(type='file', uri='/abc/{{symbol}}.json`
In this case, uri will not be taken as a dynamic parameter even we have registered as a supported dynamic option.

This is a fix for that issue.
