### PR TITLE
Changed invalid cast from long to int

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/selector/attribute/aggregator/AvgAttributeAggregator.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/selector/attribute/aggregator/AvgAttributeAggregator.java
@@ -188,7 +188,7 @@ public class AvgAttributeAggregator extends AttributeAggregator {
         @Override
         public void restoreState(Map<String, Object> state) {
             value = (double) state.get("Value");
-            count = (int) state.get("Count");
+            count = (long) state.get("Count");
         }
     }
 
@@ -240,7 +240,7 @@ public class AvgAttributeAggregator extends AttributeAggregator {
         @Override
         public void restoreState(Map<String, Object> state) {
             value = (double) state.get("Value");
-            count = (int) state.get("Count");
+            count = (long) state.get("Count");
         }
     }
 
@@ -292,7 +292,7 @@ public class AvgAttributeAggregator extends AttributeAggregator {
         @Override
         public void restoreState(Map<String, Object> state) {
             value = (double) state.get("Value");
-            count = (int) state.get("Count");
+            count = (long) state.get("Count");
         }
 
     }
@@ -345,7 +345,7 @@ public class AvgAttributeAggregator extends AttributeAggregator {
         @Override
         public void restoreState(Map<String, Object> state) {
             value = (double) state.get("Value");
-            count = (int) state.get("Count");
+            count = (long) state.get("Count");
         }
 
     }


### PR DESCRIPTION
Variable 'count' is of type 'long'. Hence all casting should be to 'long' instead of 'int' when the "Count" object is retrieved from the 'state' map.