### PR TITLE
add method 'getAllconfigs' to the ConfigReader interface.

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/config/ConfigReader.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/config/ConfigReader.java
@@ -18,10 +18,15 @@
 
 package org.wso2.siddhi.core.util.config;
 
+import java.util.Map;
+
 /**
  * Siddhi Configuration Reader
  */
 public interface ConfigReader {
 
     String readConfig(String name, String defaultValue);
+
+    Map<String, String> getAllConfigs();
+
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/config/InMemoryConfigReader.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/config/InMemoryConfigReader.java
@@ -18,6 +18,7 @@
 
 package org.wso2.siddhi.core.util.config;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,5 +42,16 @@ public class InMemoryConfigReader implements ConfigReader {
         } else {
             return defaultValue;
         }
+    }
+
+    @Override
+    public Map<String, String> getAllConfigs() {
+        Map<String, String> map = new HashMap<>();
+        for (Map.Entry<String, String> config : configs.entrySet()) {
+            if (config.getKey().startsWith(keyPrefix + ".")) {
+                map.put(config.getKey().replaceFirst(keyPrefix + ".", ""), config.getValue());
+            }
+        }
+        return map;
     }
 }


### PR DESCRIPTION
add a method 'getAllconfigs' to the ConfigReader interface and implemented that method in InMemoryConfigReader in a way that returns a map which contains all configuration for the corresponding 'keyPrefix'.  