### PR TITLE
Add pattern to detect events that are not arrived

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentLogicalPostStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentLogicalPostStateProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.input.stream.state;
+
+import org.wso2.siddhi.core.event.ComplexEventChunk;
+import org.wso2.siddhi.core.event.state.StateEvent;
+import org.wso2.siddhi.core.event.stream.StreamEvent;
+import org.wso2.siddhi.query.api.execution.query.input.state.LogicalStateElement;
+
+/**
+ * Post-state processor of not logical operator.
+ */
+public class AbsentLogicalPostStateProcessor extends LogicalPostStateProcessor {
+
+
+    public AbsentLogicalPostStateProcessor(LogicalStateElement.Type type) {
+        super(type);
+    }
+
+
+    protected void process(StateEvent stateEvent, ComplexEventChunk complexEventChunk) {
+
+        // Mark the state changed
+        thisStatePreProcessor.stateChanged();
+
+        // Update the timestamp
+        StreamEvent streamEvent = stateEvent.getStreamEvent(stateId);
+
+        // This is the notification to AbsentStreamPreStateProcessor that this event has been processed
+        this.isEventReturned = true;
+
+        ((AbsentPreStateProcessor) thisStatePreProcessor).updateLastArrivalTime(streamEvent.getTimestamp());
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentLogicalPreStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentLogicalPreStateProcessor.java
@@ -1,0 +1,365 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.siddhi.core.query.input.stream.state;
+
+import org.wso2.siddhi.core.event.ComplexEventChunk;
+import org.wso2.siddhi.core.event.state.StateEvent;
+import org.wso2.siddhi.core.event.stream.StreamEvent;
+import org.wso2.siddhi.core.util.Scheduler;
+import org.wso2.siddhi.query.api.execution.query.input.state.LogicalStateElement;
+import org.wso2.siddhi.query.api.execution.query.input.stream.StateInputStream;
+import org.wso2.siddhi.query.api.expression.constant.TimeConstant;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Logical not processor.
+ */
+public class AbsentLogicalPreStateProcessor extends LogicalPreStateProcessor implements AbsentPreStateProcessor {
+
+    /**
+     * Scheduler to trigger events after the waitingTime.
+     */
+    private Scheduler scheduler;
+
+    /**
+     * The time defined by 'for' in an absence pattern.
+     */
+    private long waitingTime = -1;
+
+    /**
+     * The timestamp of the last event received by this processor.
+     */
+    private volatile long lastArrivalTime;
+
+    /**
+     * Lock to synchronize the both {@link AbsentLogicalPreStateProcessor}s in the pattern.
+     */
+    private final ReentrantLock lock;
+
+    /**
+     * This flag turns to false after processing the first event if 'every' is not used.
+     */
+    private boolean active = true;
+
+    public AbsentLogicalPreStateProcessor(LogicalStateElement.Type type, StateInputStream.Type stateType,
+                                          List<Map.Entry<Long, Set<Integer>>> withinStates, TimeConstant waitingTime,
+                                          ReentrantLock lock) {
+        super(type, stateType, withinStates);
+        this.lock = lock;
+        if (waitingTime != null) {
+            this.waitingTime = waitingTime.value();
+        }
+    }
+
+    @Override
+    public void updateLastArrivalTime(long timestamp) {
+
+        this.lock.lock();
+        try {
+            this.lastArrivalTime = timestamp;
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
+    @Override
+    public void addState(StateEvent stateEvent) {
+
+        if (!this.active) {
+            return;
+        }
+        this.lock.lock();
+        try {
+            super.addState(stateEvent);
+            if (!isStartState) {
+                if (waitingTime != -1) {
+                    scheduler.notifyAt(stateEvent.getTimestamp() + waitingTime);
+                    if (partnerStatePreProcessor instanceof AbsentLogicalPreStateProcessor) {
+                        ((AbsentLogicalPreStateProcessor) partnerStatePreProcessor).scheduler.notifyAt(stateEvent
+                                .getTimestamp() + ((AbsentLogicalPreStateProcessor) partnerStatePreProcessor)
+                                .waitingTime);
+                    }
+                }
+            }
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
+    @Override
+    public void addEveryState(StateEvent stateEvent) {
+
+        StateEvent clonedEvent = stateEventCloner.copyStateEvent(stateEvent);
+        if (clonedEvent.getStreamEvent(stateId) != null) {
+            // Set the timestamp of the last arrived event
+            clonedEvent.setTimestamp(clonedEvent.getStreamEvent(stateId).getTimestamp());
+        }
+        clonedEvent.setEvent(stateId, null);
+        clonedEvent.setEvent(partnerStatePreProcessor.stateId, null);
+        // Start state takes events from newAndEveryStateEventList
+        newAndEveryStateEventList.add(clonedEvent);
+        partnerStatePreProcessor.newAndEveryStateEventList.add(clonedEvent);
+    }
+
+    @Override
+    public void process(ComplexEventChunk complexEventChunk) {
+
+        if (!this.active) {
+            return;
+        }
+        this.lock.lock();
+        boolean notProcessed = true;
+        try {
+            long currentTime = complexEventChunk.getFirst().getTimestamp();
+            if (currentTime >= this.lastArrivalTime + waitingTime) {
+
+                ComplexEventChunk<StateEvent> retEventChunk = new ComplexEventChunk<>(false);
+
+                Iterator<StateEvent> iterator;
+                if (isStartState && stateType == StateInputStream.Type.SEQUENCE && newAndEveryStateEventList.isEmpty()
+                        && pendingStateEventList.isEmpty()) {
+
+                    StateEvent stateEvent = stateEventPool.borrowEvent();
+                    addState(stateEvent);
+                } else if (stateType == StateInputStream.Type.SEQUENCE && !newAndEveryStateEventList.isEmpty()) {
+                    this.resetState();
+                }
+
+                this.updateState();
+                iterator = pendingStateEventList.iterator();
+
+                while (iterator.hasNext()) {
+                    StateEvent stateEvent = iterator.next();
+
+                    // Remove expired events based on within
+                    if (withinStates.size() > 0) {
+                        if (isExpired(stateEvent, currentTime)) {
+                            iterator.remove();
+                            continue;
+                        }
+                    }
+
+                    // Collect the events that came before the waiting time
+                    if (waitingTimePassed(currentTime, stateEvent)) {
+
+                        iterator.remove();
+
+                        if (logicalType == LogicalStateElement.Type.OR && stateEvent.getStreamEvent
+                                (partnerStatePreProcessor.getStateId()) == null) {
+                            // OR Partner not received
+                            stateEvent.addEvent(stateId, streamEventPool.borrowEvent());
+                            retEventChunk.add(stateEvent);
+                        } else if (logicalType == LogicalStateElement.Type.AND && stateEvent.getStreamEvent
+                                (partnerStatePreProcessor.getStateId()) != null) {
+                            // AND partner received but didn't send out
+                            retEventChunk.add(stateEvent);
+                        } else if (logicalType == LogicalStateElement.Type.AND && stateEvent.getStreamEvent
+                                (partnerStatePreProcessor.getStateId()) == null) {
+                            // AND partner didn't receive
+                            // Let the partner to process or not
+                            stateEvent.addEvent(stateId, streamEventPool.borrowEvent());
+                        }
+                    }
+                }
+
+                retEventChunk.reset();
+                notProcessed = retEventChunk.getFirst() == null;
+                while (retEventChunk.hasNext()) {
+                    StateEvent stateEvent = retEventChunk.next();
+                    retEventChunk.remove();
+                    sendEvent(stateEvent);
+                }
+
+                this.lastArrivalTime = 0;
+            }
+        } finally {
+            this.lock.unlock();
+        }
+
+        if (thisStatePostProcessor.nextEveryStatePerProcessor != null || (notProcessed && isStartState)) {
+            // If every or (notProcessed and startState), schedule again
+            long nextBreak;
+            if (lastArrivalTime == 0) {
+                nextBreak = siddhiAppContext.getTimestampGenerator().currentTime() + waitingTime;
+            } else {
+                nextBreak = lastArrivalTime + waitingTime;
+            }
+            this.scheduler.notifyAt(nextBreak);
+        }
+    }
+
+    private boolean waitingTimePassed(long currentTime, StateEvent event) {
+        if (event.getStreamEvent(stateId) == null) {
+            // Not processed already
+            return currentTime >= event.getTimestamp() + waitingTime;
+        } else {
+            // Already processed by this processor and added back due to 'every'
+            return currentTime >= event.getStreamEvent(stateId).getTimestamp() + waitingTime;
+        }
+    }
+
+    private void sendEvent(StateEvent stateEvent) {
+        if (thisStatePostProcessor.nextProcessor != null) {
+            thisStatePostProcessor.nextProcessor.process(new ComplexEventChunk<>(stateEvent,
+                    stateEvent, false));
+        }
+        if (thisStatePostProcessor.nextStatePerProcessor != null) {
+            thisStatePostProcessor.nextStatePerProcessor.addState(stateEvent);
+        }
+        if (thisStatePostProcessor.nextEveryStatePerProcessor != null) {
+            thisStatePostProcessor.nextEveryStatePerProcessor.addEveryState(stateEvent);
+        } else if (isStartState) {
+            this.active = false;
+            if (logicalType == LogicalStateElement.Type.OR &&
+                    partnerStatePreProcessor instanceof AbsentLogicalPreStateProcessor) {
+                ((AbsentLogicalPreStateProcessor) partnerStatePreProcessor).active = false;
+            }
+        }
+        if (thisStatePostProcessor.callbackPreStateProcessor != null) {
+            thisStatePostProcessor.callbackPreStateProcessor.startStateReset();
+        }
+    }
+
+    @Override
+    public ComplexEventChunk<StateEvent> processAndReturn(ComplexEventChunk complexEventChunk) {
+
+        ComplexEventChunk<StateEvent> returnEventChunk = new ComplexEventChunk<>(false);
+
+        if (!this.active) {
+            return returnEventChunk;
+        }
+        complexEventChunk.reset();
+        StreamEvent streamEvent = (StreamEvent) complexEventChunk.next(); //Sure only one will be sent
+
+        this.lock.lock();
+        try {
+            for (Iterator<StateEvent> iterator = pendingStateEventList.iterator(); iterator.hasNext(); ) {
+                StateEvent stateEvent = iterator.next();
+                if (withinStates.size() > 0) {
+                    if (isExpired(stateEvent, streamEvent.getTimestamp())) {
+                        iterator.remove();
+                        continue;
+                    }
+                }
+                if (logicalType == LogicalStateElement.Type.OR &&
+                        stateEvent.getStreamEvent(partnerStatePreProcessor.getStateId()) != null) {
+                    iterator.remove();
+                    continue;
+                }
+                StreamEvent currentStreamEvent = stateEvent.getStreamEvent(stateId);
+                stateEvent.setEvent(stateId, streamEventCloner.copyStreamEvent(streamEvent));
+                process(stateEvent);
+                if (waitingTime != -1 || (stateType == StateInputStream.Type.SEQUENCE &&
+                        logicalType == LogicalStateElement.Type.AND && thisStatePostProcessor
+                        .nextEveryStatePerProcessor != null)) {
+                    // Reset to the original state after processing
+                    stateEvent.setEvent(stateId, currentStreamEvent);
+                }
+                if (this.thisLastProcessor.isEventReturned()) {
+                    this.thisLastProcessor.clearProcessedEvent();
+                    // The event has passed the filter condition. So remove from being an absent candidate.
+                    iterator.remove();
+                    if (stateType == StateInputStream.Type.SEQUENCE) {
+                        partnerStatePreProcessor.pendingStateEventList.remove(stateEvent);
+                    }
+                }
+                if (!stateChanged) {
+                    switch (stateType) {
+                        case PATTERN:
+                            stateEvent.setEvent(stateId, null);
+                            break;
+                        case SEQUENCE:
+                            stateEvent.setEvent(stateId, null);
+                            iterator.remove();
+                            break;
+                    }
+                }
+            }
+        } finally {
+            this.lock.unlock();
+        }
+        return returnEventChunk;
+    }
+
+    @Override
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        return this.scheduler;
+    }
+
+    @Override
+    public void start() {
+        if (isStartState && waitingTime != -1 && active) {
+            this.lock.lock();
+            try {
+                this.scheduler.notifyAt(this.siddhiAppContext.getTimestampGenerator().currentTime() +
+                        waitingTime);
+            } finally {
+                this.lock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public void stop() {
+        // Scheduler will be stopped automatically
+        // Nothing to stop here
+    }
+
+    public boolean partnerCanProceed(StateEvent stateEvent) {
+
+        boolean process;
+        if (stateType == StateInputStream.Type.SEQUENCE && thisStatePostProcessor.nextEveryStatePerProcessor == null
+                && this.lastArrivalTime > 0) {
+            process = false;
+        } else {
+            if (this.waitingTime == -1) {
+                // for time is not defined and event is not received by absent processor
+                if (thisStatePostProcessor.nextEveryStatePerProcessor == null) {
+                    process = stateEvent.getStreamEvent(this.stateId) == null;
+                } else {
+                    // Every
+                    if (this.lastArrivalTime > 0) {
+                        process = false;
+                        this.lastArrivalTime = 0;
+                        this.init();
+                    } else {
+                        process = true;
+                    }
+                }
+            } else if (stateEvent.getStreamEvent(this.stateId) != null) {
+                // for time is defined
+                process = true;
+            } else {
+                process = false;
+            }
+        }
+
+        return process;
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentPreStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentPreStateProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.input.stream.state;
+
+import org.wso2.siddhi.core.query.processor.SchedulingProcessor;
+import org.wso2.siddhi.core.util.extension.holder.EternalReferencedHolder;
+
+/**
+ * PreStateProcessor of events not received by Siddhi.
+ */
+public interface AbsentPreStateProcessor extends SchedulingProcessor, EternalReferencedHolder {
+
+    /**
+     * Update the timestamp of the event arrived to this processor and met the filter conditions.
+     *
+     * @param timestamp the timestamp if the event
+     */
+    void updateLastArrivalTime(long timestamp);
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentStreamPostStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentStreamPostStateProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.input.stream.state;
+
+import org.wso2.siddhi.core.event.ComplexEventChunk;
+import org.wso2.siddhi.core.event.state.StateEvent;
+import org.wso2.siddhi.core.event.stream.StreamEvent;
+
+/**
+ * PostStateProcessor to handle not pattern state processors.
+ */
+public class AbsentStreamPostStateProcessor extends StreamPostStateProcessor {
+
+    /**
+     * This method just mark the state changed but does not send the stateEvent to the next processors.
+     *
+     * @param stateEvent        the state event
+     * @param complexEventChunk the ComplexEventChunk
+     */
+    protected void process(StateEvent stateEvent, ComplexEventChunk complexEventChunk) {
+
+        // Mark the state changed
+        thisStatePreProcessor.stateChanged();
+
+        // Update the timestamp
+        StreamEvent streamEvent = stateEvent.getStreamEvent(stateId);
+        stateEvent.setTimestamp(streamEvent.getTimestamp());
+
+        // This is the notification to AbsentStreamPreStateProcessor that this event has been processed
+        this.isEventReturned = true;
+
+        if (thisStatePreProcessor.isStartState) {
+            if (nextEveryStatePerProcessor != null && nextEveryStatePerProcessor == thisStatePreProcessor) {
+                // nextEveryStatePerProcessor refers the AbsentStreamPreStateProcessor
+                nextEveryStatePerProcessor.addEveryState(stateEvent);
+            }
+        }
+
+        ((AbsentPreStateProcessor) thisStatePreProcessor).updateLastArrivalTime(streamEvent.getTimestamp());
+    }
+
+
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentStreamPreStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/AbsentStreamPreStateProcessor.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.input.stream.state;
+
+import org.wso2.siddhi.core.event.ComplexEventChunk;
+import org.wso2.siddhi.core.event.state.StateEvent;
+import org.wso2.siddhi.core.util.Scheduler;
+import org.wso2.siddhi.query.api.execution.query.input.stream.StateInputStream;
+import org.wso2.siddhi.query.api.expression.constant.TimeConstant;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pre processor of not operator.
+ */
+public class AbsentStreamPreStateProcessor extends StreamPreStateProcessor implements AbsentPreStateProcessor {
+
+    /**
+     * Scheduler to trigger events after the waitingTime.
+     */
+    private Scheduler scheduler;
+
+    /**
+     * The time defined by 'for' in an absence pattern.
+     */
+    private long waitingTime = -1;
+
+    /**
+     * The timestamp of the last event received by this processor.
+     */
+    private long lastArrivalTime;
+
+    /**
+     * This flag turns to false after processing the first event if 'every' is not used.
+     * This is used to process only one pattern if 'every' is not used.
+     */
+    private boolean active = true;
+
+
+    /**
+     * Construct an AbsentStreamPreStateProcessor object.
+     *
+     * @param stateType    PATTERN or SEQUENCE
+     * @param withinStates the time defined by 'within' keyword
+     * @param waitingTime  the waiting time defined by 'for' keyword
+     */
+    public AbsentStreamPreStateProcessor(StateInputStream.Type stateType, List<Map.Entry<Long, Set<Integer>>>
+            withinStates, TimeConstant waitingTime) {
+        super(stateType, withinStates);
+        // Not operator always has 'for' time
+        this.waitingTime = waitingTime.value();
+    }
+
+    @Override
+    public void updateLastArrivalTime(long timestamp) {
+        synchronized (this) {
+            this.lastArrivalTime = timestamp;
+        }
+    }
+
+    @Override
+    public void addState(StateEvent stateEvent) {
+
+        if (!this.active) {
+            // 'every' keyword is not used and already a pattern is processed
+            return;
+        }
+        synchronized (this) {
+            if (stateType == StateInputStream.Type.SEQUENCE) {
+                newAndEveryStateEventList.clear();
+                newAndEveryStateEventList.add(stateEvent);
+            } else {
+                newAndEveryStateEventList.add(stateEvent);
+            }
+        }
+        // If this is the first processor, nothing to receive from previous patterns
+        if (!isStartState) {
+            // Start the scheduler
+            scheduler.notifyAt(stateEvent.getTimestamp() + waitingTime);
+        }
+    }
+
+    @Override
+    public void resetState() {
+
+        // Clear the events added by the previous processor
+        pendingStateEventList.clear();
+        if (isStartState) {
+            if (stateType == StateInputStream.Type.SEQUENCE &&
+                    thisStatePostProcessor.nextEveryStatePerProcessor == null &&
+                    !((StreamPreStateProcessor) thisStatePostProcessor.nextStatePerProcessor)
+                            .pendingStateEventList.isEmpty()) {
+                // Sequence without 'every' keyword and the next processor has pending events to be processed
+                return;
+            }
+            // Start state needs a new event
+            init();
+        }
+    }
+
+    @Override
+    public void process(ComplexEventChunk complexEventChunk) {
+
+        if (!this.active) {
+            // Every keyword is not used and already a pattern is processed
+            return;
+        }
+        boolean notProcessed = true;
+        long currentTime = complexEventChunk.getFirst().getTimestamp();
+        if (currentTime >= this.lastArrivalTime + waitingTime) {
+            synchronized (this) {
+                // If the process method is called, it is guaranteed that the waitingTime is passed
+                boolean initialize;
+                initialize = isStartState && newAndEveryStateEventList.isEmpty() && pendingStateEventList.isEmpty();
+                if (initialize && stateType == StateInputStream.Type.SEQUENCE &&
+                        thisStatePostProcessor.nextEveryStatePerProcessor == null && this.lastArrivalTime > 0) {
+                    // Sequence with no every but an event arrived
+                    initialize = false;
+                }
+
+                if (initialize) {
+                    // This is the first processor and no events received so far
+                    StateEvent stateEvent = stateEventPool.borrowEvent();
+                    addState(stateEvent);
+                } else if (stateType == StateInputStream.Type.SEQUENCE && !newAndEveryStateEventList.isEmpty()) {
+                    this.resetState();
+                }
+
+                this.updateState();
+
+                ComplexEventChunk<StateEvent> retEventChunk = new ComplexEventChunk<>(false);
+
+                Iterator<StateEvent> iterator = pendingStateEventList.iterator();
+                while (iterator.hasNext()) {
+                    StateEvent event = iterator.next();
+                    // Remove expired events based on within
+                    if (withinStates.size() > 0) {
+                        if (isExpired(event, currentTime)) {
+                            iterator.remove();
+                            continue;
+                        }
+                    }
+                    // Collect the events that came before the waiting time
+                    if (currentTime >= event.getTimestamp() + waitingTime) {
+                        iterator.remove();
+                        event.setTimestamp(currentTime);
+                        retEventChunk.add(event);
+                    }
+                }
+
+                notProcessed = retEventChunk.getFirst() == null;
+                while (retEventChunk.hasNext()) {
+                    StateEvent stateEvent = retEventChunk.next();
+                    retEventChunk.remove();
+                    sendEvent(stateEvent);
+                }
+            }
+            this.lastArrivalTime = 0;
+        }
+        if (thisStatePostProcessor.nextEveryStatePerProcessor == this || (notProcessed && isStartState)) {
+            // If every or (notProcessed and startState), schedule again
+            long nextBreak;
+            if (lastArrivalTime == 0) {
+                nextBreak = currentTime + waitingTime;
+            } else {
+                nextBreak = lastArrivalTime + waitingTime;
+            }
+            this.scheduler.notifyAt(nextBreak);
+        }
+
+    }
+
+    private void sendEvent(StateEvent stateEvent) {
+        if (thisStatePostProcessor.nextProcessor != null) {
+            thisStatePostProcessor.nextProcessor.process(new ComplexEventChunk<>(stateEvent, stateEvent, false));
+        }
+        if (thisStatePostProcessor.nextStatePerProcessor != null) {
+            thisStatePostProcessor.nextStatePerProcessor.addState(stateEvent);
+        }
+        if (thisStatePostProcessor.nextEveryStatePerProcessor != null) {
+            thisStatePostProcessor.nextEveryStatePerProcessor.addEveryState(stateEvent);
+        } else if (isStartState) {
+            this.active = false;
+        }
+        if (thisStatePostProcessor.callbackPreStateProcessor != null) {
+            thisStatePostProcessor.callbackPreStateProcessor.startStateReset();
+        }
+    }
+
+    @Override
+    public ComplexEventChunk<StateEvent> processAndReturn(ComplexEventChunk complexEventChunk) {
+
+        if (!this.active) {
+            return new ComplexEventChunk<>(false);
+        }
+        ComplexEventChunk<StateEvent> event = super.processAndReturn(complexEventChunk);
+
+        StateEvent firstEvent = event.getFirst();
+        if (firstEvent != null) {
+            event = new ComplexEventChunk<>(false);
+        }
+        // Always return an empty event
+        return event;
+    }
+
+    @Override
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        return this.scheduler;
+    }
+
+    @Override
+    public void start() {
+        // Start automatically only if it is the start state and 'for' time is defined
+        // Otherwise, scheduler will be started in the addState method
+        if (isStartState && waitingTime != -1 && active) {
+            synchronized (this) {
+                this.scheduler.notifyAt(this.siddhiAppContext.getTimestampGenerator().currentTime() + waitingTime);
+            }
+        }
+    }
+
+    @Override
+    public void stop() {
+        // Scheduler will be stopped automatically
+        // Nothing to stop here
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/LogicalPostStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/LogicalPostStateProcessor.java
@@ -59,7 +59,15 @@ public class LogicalPostStateProcessor extends StreamPostStateProcessor {
     protected void process(StateEvent stateEvent, ComplexEventChunk complexEventChunk) {
         switch (type) {
             case AND:
-                if (stateEvent.getStreamEvent(partnerPreStateProcessor.getStateId()) != null) {
+                boolean process = false;
+                if (partnerPreStateProcessor instanceof AbsentLogicalPreStateProcessor) {
+                    process = ((AbsentLogicalPreStateProcessor) partnerPreStateProcessor).partnerCanProceed(stateEvent);
+                } else if (stateEvent.getStreamEvent(partnerPreStateProcessor.getStateId()) != null) {
+                    // Event received from a present processor
+                    process = true;
+                }
+
+                if (process) {
                     super.process(stateEvent, complexEventChunk);
                 } else {
                     thisStatePreProcessor.stateChanged();
@@ -73,7 +81,7 @@ public class LogicalPostStateProcessor extends StreamPostStateProcessor {
                     partnerPostStateProcessor.isEventReturned = true;
                 }
                 break;
-            case NOT:
+            default:
                 break;
         }
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/LogicalPreStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/input/stream/state/LogicalPreStateProcessor.java
@@ -34,8 +34,8 @@ import java.util.Set;
  */
 public class LogicalPreStateProcessor extends StreamPreStateProcessor {
 
-    private LogicalStateElement.Type logicalType;
-    private LogicalPreStateProcessor partnerStatePreProcessor;
+    protected LogicalStateElement.Type logicalType;
+    protected LogicalPreStateProcessor partnerStatePreProcessor;
 
     public LogicalPreStateProcessor(LogicalStateElement.Type type, StateInputStream.Type stateType, List<Map
             .Entry<Long, Set<Integer>>> withinStates) {
@@ -131,7 +131,7 @@ public class LogicalPreStateProcessor extends StreamPreStateProcessor {
         for (Iterator<StateEvent> iterator = pendingStateEventList.iterator(); iterator.hasNext(); ) {
             StateEvent stateEvent = iterator.next();
             if (withinStates.size() > 0) {
-                if (isExpired(stateEvent, streamEvent)) {
+                if (isExpired(stateEvent, streamEvent.getTimestamp())) {
                     iterator.remove();
                     continue;
                 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentPatternTestCase.java
@@ -1,0 +1,1863 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.pattern.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - A -> not B for 1 sec
+ * - not A for 1 sec -> B
+ */
+public class AbsentPatternTestCase {
+
+    private static final Logger log = Logger.getLogger(AbsentPatternTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testQueryAbsent1() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 without sending e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent2() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 sending e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent3() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 sending e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1000);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent4() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 sending e2 for 1 sec but without satisfying the filter condition");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 50.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent6() throws InterruptedException {
+        log.info("Test the query not e1 -> e2 with e1 and e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 59.6f, 100});
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent7() throws InterruptedException {
+        log.info("Test the query not e1 -> e2 with e1 and e2 for 1 sec where e1 filter fails");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 5.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8() throws InterruptedException {
+        log.info("Test the query not e1 -> e2 with e1 and e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent9() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> not e3 with e1, e2 and e3 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent10() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> not e3 with e1, e2 and e3 which does not meet the condition for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 25.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent11() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> not e3 with e1, e2 and not e3 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent12() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent13() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 with e1, e2(condition failed) e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 8.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent14() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent15() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent16() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent17() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> e3 with e1 that fails to satisfy the condition, e2 and " +
+                "e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 5.6f, 100});
+        Thread.sleep(600);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent18() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> e3 with e1, e2 after 1 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent19() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> e3 -> not e4 for 1 sec with e1, e2, e3 and not e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> e3=Stream3[price>30] -> not Stream4[price>40] " +
+                "for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent20() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> e3 -> not e4 for 1 sec with e1, e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> e3=Stream3[price>30] -> not Stream4[price>40] " +
+                "for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent21() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> not e3 for 1 sec -> e4 with e1, e2, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 sec -> " +
+                "e4=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent22() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> not e3 for 1 sec -> e4 with e1, e2, e3, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 sec -> " +
+                "e4=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent23() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> e3-> e4 with e1, e2, e3, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] -> " +
+                "e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent24() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> not e3 for 1 sec-> e4 with e2 after 1 sec e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 " +
+                "sec -> e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "ORACLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent25() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> not e3 for 1 sec-> e4 with e1, e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 " +
+                "sec -> e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent26() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> not e3 for 1 sec-> e4 with e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> not Stream3[price>30] for 1 " +
+                "sec -> e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent27() throws InterruptedException {
+        log.info("Test the query not e1 -> e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent28() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 and e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent29() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 and e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent30() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 or e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent31() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 or e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", null, "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent32() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 or e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent33() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 and e4 with e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent34() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 or e4 with e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent35() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2<2:5> with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20]<2:5> " +
+                "select e2[0].symbol as symbol0, e2[1].symbol as symbol1, e2[2].symbol as symbol2, e2[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent36() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2<2:5> with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20]<2:5> " +
+                "select e2[0].symbol as symbol0, e2[1].symbol as symbol1, e2[2].symbol as symbol2, e2[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", null, null});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent37() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent38() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent39() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> e3 or e4 with e2 followed by 1 sec delay");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"WSO2", 25.5f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent40() throws InterruptedException {
+        log.info("Test the query not e1 -> e2 without e1 with two e2s");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"WSO2", 68.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent41() throws InterruptedException {
+        log.info("Test the query every not e1 with e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec " +
+                "select * " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent42() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 within 2 sec without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] within 2 sec " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(3100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentWithEveryPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentWithEveryPatternTestCase.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.pattern.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - every A -> not B for 1 sec
+ * - not A for 1 sec -> every B
+ */
+public class AbsentWithEveryPatternTestCase {
+
+    private static final Logger log = Logger.getLogger(AbsentWithEveryPatternTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testQuery1() throws InterruptedException {
+        log.info("Test the query every e1 -> not e2 for 1 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price1 float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>20] -> not Stream2[price1>e1.price] for 1sec " +
+                "select e1.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"GOOG"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQuery2() throws InterruptedException {
+        log.info("Test the query every e1 -> not e2 for 1 sec with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price1 float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>20] -> not Stream2[price1>e1.price] for 1sec " +
+                "select e1.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 55.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQuery3() throws InterruptedException {
+        log.info("Test the query every e1 -> not e2 for 1 sec -> e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>20] -> not Stream2[price>e1.price] for 1sec -> " +
+                "e3=Stream3[price>e1.price] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"}, new Object[]{"GOOG", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"IBM", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQuery4() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> every e2 with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1sec -> every e2=Stream2[price>20] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"GOOG"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQuery5() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> every e2 with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1sec -> every e2=Stream2[price>20] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 55.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQuery6() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec -> every e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> not Stream2[price>e1.price] for 1sec -> " +
+                "every e3=Stream3[price>e1.price] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOG"}, new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOG", 55.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 55.8f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/EveryAbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/EveryAbsentPatternTestCase.java
@@ -1,0 +1,2198 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.pattern.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - 'A -> every(not B for 1 sec)'
+ * - 'every (not A for 1 sec) -> B'
+ * - 'A -> every(not B and C)'
+ * - 'every(not A and B) -> C'
+ * - 'A -> every(not B for 1 sec and C)'
+ * - 'every(not A for 1 sec and B) -> C'
+ */
+public class EveryAbsentPatternTestCase {
+
+    private static final Logger log = Logger.getLogger(EveryAbsentPatternTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testQueryAbsent1() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec without sending e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> every not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(3200);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 3, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent2() throws InterruptedException {
+        log.info("Test the query (e1 -> every not e2 for 900 milliseconds) within 2 sec without sending e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (e1=Stream1[price>20] -> every not Stream2[price>e1.price] for 900 milliseconds) within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(3200);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent3() throws InterruptedException {
+        log.info("Test the query (e1 -> every not e2 for 900 milliseconds) within 2 sec without sending e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "@app:playback " +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream TimerStream (symbol string); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (e1=Stream1[price>20] -> every not Stream2[price>e1.price] for 900 milliseconds) within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler timerStream = siddhiAppRuntime.getInputHandler("TimerStream");
+
+        siddhiAppRuntime.start();
+
+        long timestamp = System.currentTimeMillis();
+        stream1.send(timestamp, new Object[]{"WSO2", 55.6f, 100});
+        timestamp += 1000;
+        timerStream.send(timestamp, new Object[]{"UPDATE-TIME"});
+        Thread.sleep(100);
+        Assert.assertEquals("Number of success events after first timeout", 1, inEventCount);
+
+        timestamp += 1000;
+        timerStream.send(timestamp, new Object[]{"UPDATE-TIME"});
+        Thread.sleep(100);
+        Assert.assertEquals("Number of success events after second timeout", 2, inEventCount);
+
+        timestamp += 1000;
+        timerStream.send(timestamp, new Object[]{"UPDATE-TIME"});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent4() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 sending e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> every not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 sending e2 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent6() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 sending e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> every not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent7() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 sending e2 for 1 sec but without satisfying the filter condition");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20] -> every not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 50.7f, 100});
+        Thread.sleep(2100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8() throws InterruptedException {
+        log.info("Test the query every not e1 -> e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2200);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent9() throws InterruptedException {
+        log.info("Test the query every not e1 -> e2 with e1 and e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 59.6f, 100});
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent10() throws InterruptedException {
+        log.info("Test the query every not e1 -> e2 with e1 and e2 for 1 sec where e1 filter fails");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(500);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent11() throws InterruptedException {
+        log.info("Test the query every not e1 -> e2 with e1 and e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent12() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> every not e3 with e1, e2 and e3 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent13() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> every not e3 with e1, e2 and e3 which does not meet the condition for 1 " +
+                "sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"GOOGLE", 25.7f, 100});
+        Thread.sleep(500);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent14() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> every not e3 with e1, e2 and not e3 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"}, new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(2100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent15() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent16() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 with e1, e2(condition failed) e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(1000);
+        stream2.send(new Object[]{"IBM", 8.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent17() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent18() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 -> e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent19() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 -> e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent20() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 -> e3 with e1 that fails to satisfy the condition, e2 " +
+                "and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 5.6f, 100});
+        Thread.sleep(600);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent21() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 -> e3 with e1, e2 after 2 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent22() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> e3 -> every not e4 for 1 sec with e1, e2, e3 and not e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> e3=Stream3[price>30] -> every not " +
+                "Stream4[price>40] for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "GOOGLE"}, new Object[]{"WSO2",
+                "IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
+        Thread.sleep(2100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent23() throws InterruptedException {
+        log.info("Test the query (e1 -> e2 -> e3 -> every not e4 for 1 sec) within 2 sec with e1, e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (e1=Stream1[price>10] -> e2=Stream2[price>20] -> e3=Stream3[price>30] -> every not " +
+                "Stream4[price>40] for 1 sec) within 2 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent24() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> every not e3 for 1 sec -> e4 with e1, e2, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 sec -> " +
+                "e4=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"}, new Object[]{"WSO2",
+                "IBM", "ORACLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(2100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent25() throws InterruptedException {
+        log.info("Test the query e1 -> e2 -> every not e3 for 1 sec -> e4 with e1, e2, e3, and e4 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 sec -> " +
+                "e4=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent26() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 -> e3-> e4 with e1, e2, e3, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> e3=Stream3[price>30] -> " +
+                "e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent27() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> every not e3 for 1 sec-> e4 with e2 after 1 sec e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 " +
+                "sec -> e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "ORACLE"}, new Object[]{"IBM", "ORACLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(2100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent28() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> every not e3 for 1 sec-> e4 with e1, e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 " +
+                "sec -> e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent29() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> e2 -> every not e3 for 1 sec-> e4 with e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] -> every not Stream3[price>30] for 1 " +
+                "sec -> e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent30() throws InterruptedException {
+        log.info("Test the query every not e1 -> e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec -> e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent31() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2<2:5> with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20]<2:5> " +
+                "select e2[0].symbol as symbol0, e2[1].symbol as symbol1, e2[2].symbol as symbol2, e2[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent32() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2<2:5> with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20]<2:5> " +
+                "select e2[0].symbol as symbol0, e2[1].symbol as symbol1, e2[2].symbol as symbol2, e2[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", null, null}, new Object[]{"WSO2",
+                "IBM", null, null});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent33() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec -> e2 with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec -> e2=Stream2[price>20] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent34() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 and e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", "GOOGLE"}, new Object[]{"IBM",
+                "WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent35() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 and e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent36() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 or e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", null}, new Object[]{"IBM", "WSO2",
+                null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent37() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 or e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", null, "GOOGLE"}, new Object[]{"IBM", null,
+                "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(2100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent38() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 or e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent39() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 and e4 with e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent40() throws InterruptedException {
+        log.info("Test the query e1 -> every not e2 for 1 sec -> e3 or e4 with e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every not Stream2[price>20] for 1 sec -> e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent41() throws InterruptedException {
+        log.info("Test the query e1 -> every (not e2 and e3) with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every (not Stream2[price>20] and e3=Stream3[price>30]) " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "ORACLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent42() throws InterruptedException {
+        log.info("Test the query e1 -> every (not e2 and e3) with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every (not Stream2[price>20] and e3=Stream3[price>30]) " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent43() throws InterruptedException {
+        log.info("Test the query every (not e1 and e2) -> e3 with e2 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] and e2=Stream2[price>20]) -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"WSO2", 26.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent44() throws InterruptedException {
+        log.info("Test the query every (not e1 and e2) -> e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] and e2=Stream2[price>20]) -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent45() throws InterruptedException {
+        log.info("Test the query e1 -> every (not e2 for 1 sec and e3) with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "ORACLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent46() throws InterruptedException {
+        log.info("Test the query e1 -> every (not e2 for 1 sec and e3) with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent47() throws InterruptedException {
+        log.info("Test the query e1 -> every (not e2 for 1 sec and e3) with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> every (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent48() throws InterruptedException {
+        log.info("Test the query every (e1 for 1 sec and e2) -> e3 with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]) -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent49() throws InterruptedException {
+        log.info("Test the query every (not e1 and e2) -> e3 with e1, e2, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] and e2=Stream2[price>20]) -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
@@ -1,0 +1,2995 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.pattern.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - 'A -> not B and C'
+ * - 'not A and B -> C'
+ * - 'A -> not B for 1 sec and C'
+ * - 'A -> not B for 1 sec or C'
+ * - 'A -> not B for 1 sec and not C for 1 sec'
+ * - 'A -> not B for 1 sec or not C for 1 sec'
+ * - 'not A for 1 sec and not B for 1 sec -> C'
+ * - 'not A for 1 sec or not B for 1 sec -> C'
+ */
+public class LogicalAbsentPatternTestCase {
+
+    private static final Logger log = Logger.getLogger(LogicalAbsentPatternTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+        assertionErrors.clear();
+    }
+
+    @Test
+    public void testQueryAbsent1() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 and e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent2() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 and e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent3() throws InterruptedException {
+        log.info("Test the query not e1 and e2 -> e3 with e2 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent4() throws InterruptedException {
+        log.info("Test the query not e1 and e2 -> e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec and e3 with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5_1() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec and e3 with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(500);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(600);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5_2() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec and e3 with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent6() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec and e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent7() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec and e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2 -> e3 with e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8_1() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2 -> e3 with e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8_2() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2 -> e3 with e1, e2 after 1 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(600);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent9() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2 -> e3 with e2 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent10() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2 -> e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent11() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec or e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent12() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec or e3 with e1 and e3 with extra 1 sec to make sure no " +
+                "duplicates");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent13() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec or e3 with e1 only with 1 sec waiting");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent14() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec or e3 with e1 only with no waiting");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent15() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec or e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent16() throws InterruptedException {
+        log.info("Test the query e1 -> not e2 for 1 sec or e3 with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent17() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec or e2 -> e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec or e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"WSO2", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent18() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec or e2 -> e3 with e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec or e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent19() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec or e2 -> e3 with e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec or e2=Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent20() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 and e3) within 1 sec with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] and e3=Stream3[price>30]) within 1 sec " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent21() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 and e3) within 1 sec with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] and e3=Stream3[price>30]) within 1 sec " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent22() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 and e3) within 1 sec with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] and e3=Stream3[price>30]) within 1 sec " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent23() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec and e3) within 2 sec with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) within 2 sec" +
+                " " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent24() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec and e3) within 2 sec with e1 and e3 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) within 2 sec" +
+                " " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent25() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent26() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent27() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent28() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"ORACLE", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent29() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent30() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent31() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent32() throws InterruptedException {
+        log.info("Test the query e1 -> (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 " +
+                "sec" +
+                " " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"ORACLE", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent33() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec) -> e3 with e3 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent34() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec) -> e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"IBM", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent35() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec) -> e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent36() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec) -> e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent37() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec) -> e3 with e3 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent38() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec) -> e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"IBM", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent39() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec) -> e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent40() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec) -> e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec) -> e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent41() throws InterruptedException {
+        log.info("Test the query e1 -> e2 or not e3 for 1 sec with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] or not Stream3[price>30] for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOGLE", 25.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent42() throws InterruptedException {
+        log.info("Test the query e1 -> e2 or not e3 for 1 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] -> e2=Stream2[price>20] or not Stream3[price>30] for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent43() throws InterruptedException {
+        log.info("Test the query e1 or not e2 for 1 sec -> e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] or not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent44() throws InterruptedException {
+        log.info("Test the query e1 or not e2 for 1 sec -> e3 with e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] or not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent45() throws InterruptedException {
+        log.info("Test the query e1 or not e2 for 1 sec -> e3 with e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] or not Stream2[price>20] for 1 sec -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        siddhiAppRuntime.start();
+
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent46() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or not e2 for 1 sec) -> e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(300);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(800);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent47() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or not e2 for 1 sec) -> e3 with two e3s");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"}, new Object[]{"IBM"}, new
+                Object[]{"IBM"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 4, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent48() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or not e2 for 1 sec) -> e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"}, new Object[]{"WSO2"}, new
+                Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 4, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent49() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and not e2 for 1 sec) -> e3 with two (<1 sec> e3)s");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent50() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and not e2 for 1 sec) -> e3 with an e3 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent51() throws InterruptedException {
+        log.info("Test the query e1 and not e2 for 1 sec -> e3 with e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e1=Stream1[price>10] and not Stream2[price>20] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"ORACLE", "MICROSOFT"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream1.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+
+        Thread.sleep(1100);
+        stream1.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"MICROSOFT", 55.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent52() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or e2) -> e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or e2=Stream2[price>20]) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(300);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(800);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent53() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or e2) -> e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or e2=Stream2[price>20]) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+                new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 3, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent54() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or e2) -> e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or e2=Stream2[price>20]) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent55() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and e2) -> e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(2000);
+        stream2.send(new Object[]{"WSO2", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent56() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and e2) -> e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent57() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and e2) -> e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent58() throws InterruptedException {
+        log.info("Test the query every (e1 or not e2 for 1 sec) -> e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] or not Stream1[price>10] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(300);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(800);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent59() throws InterruptedException {
+        log.info("Test the query every (e1 or not e2 for 1 sec) -> e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] or not Stream1[price>10] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+                new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 3, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent60() throws InterruptedException {
+        log.info("Test the query every (e1 or not e2 for 1 sec) -> e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] or not Stream1[price>10] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent61() throws InterruptedException {
+        log.info("Test the query every (e1 and not e2 for 1 sec) -> e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] and not Stream1[price>10] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(2000);
+        stream2.send(new Object[]{"WSO2", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent62() throws InterruptedException {
+        log.info("Test the query every (e1 and not e2 for 1 sec) -> e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] and not Stream1[price>10] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent63() throws InterruptedException {
+        log.info("Test the query every (e1 and not e2 for 1 sec) -> e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] and not Stream1[price>10] for 1 sec) -> " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent64() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec -> not e2 and e3 -> e4 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec -> not Stream2[price>20] and e3=Stream3[price>30] -> " +
+                "e4=Stream4[price>40]" +
+                "select e3.symbol as symbol3, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOGLE", "ORACLE"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent65() throws InterruptedException {
+        log.info("Test the query e1 and not e2 -> e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] and not Stream2[price>20] -> e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentSequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentSequenceTestCase.java
@@ -1,0 +1,1758 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.sequence.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - 'A, not B for 1 sec'
+ * - 'not A for 1 sec, B'
+ */
+public class AbsentSequenceTestCase {
+
+    private static final Logger log = Logger.getLogger(AbsentSequenceTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testQueryAbsent1() throws InterruptedException {
+        log.info("Test the query e1, not e2 without sending e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20], not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent2() throws InterruptedException {
+        log.info("Test the query e1, not e2 sending e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20], not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent3() throws InterruptedException {
+        log.info("Test the query e1, not e2 sending e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20], not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1000);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent4() throws InterruptedException {
+        log.info("Test the query e1, not e2 sending e2 for 1 sec but without satisfying the filter condition");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>20], not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 50.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5() throws InterruptedException {
+        log.info("Test the query not e1, e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent6() throws InterruptedException {
+        log.info("Test the query not e1, e2 with e1 and e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 59.6f, 100});
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent7() throws InterruptedException {
+        log.info("Test the query not e1, e2 with e1 and e2 for 1 sec where e1 filter fails");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 5.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8() throws InterruptedException {
+        log.info("Test the query not e1, e2 with e1 and e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent9() throws InterruptedException {
+        log.info("Test the query e1, e2, not e3 with e1, e2 and e3 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent10() throws InterruptedException {
+        log.info("Test the query e1, e2, not e3 with e1, e2 and e3 which does not meet the condition for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 25.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent11() throws InterruptedException {
+        log.info("Test the query e1, e2, not e3 with e1, e2 and not e3 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], not Stream3[price>30] for 1 sec " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent12() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent13() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 with e1, e2(condition failed) e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 8.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent14() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent15() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent16() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent17() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, e3 with e1 that fails to satisfy the condition, e2 and " +
+                "e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 5.6f, 100});
+        Thread.sleep(600);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent18() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, e3 with e1, e2 after 1 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent19() throws InterruptedException {
+        log.info("Test the query e1, e2, e3, not e4 for 1 sec with e1, e2, e3 and not e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], e3=Stream3[price>30], not Stream4[price>40] " +
+                "for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent20() throws InterruptedException {
+        log.info("Test the query e1, e2, e3, not e4 for 1 sec with e1, e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], e3=Stream3[price>30], not Stream4[price>40] " +
+                "for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent21() throws InterruptedException {
+        log.info("Test the query e1, e2, not e3 for 1 sec, e4 with e1, e2, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], not Stream3[price>30] for 1 sec, " +
+                "e4=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent22() throws InterruptedException {
+        log.info("Test the query e1, e2, not e3 for 1 sec, e4 with e1, e2, e3, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20], not Stream3[price>30] for 1 sec, " +
+                "e4=Stream4[price>40] " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent23() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, e3, e4 with e1, e2, e3, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30], " +
+                "e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent24() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, not e3 for 1 sec, e4 with e2 after 1 sec e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], not Stream3[price>30] for 1 " +
+                "sec, e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "ORACLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent25() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, not e3 for 1 sec, e4 with e1, e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], not Stream3[price>30] for 1 " +
+                "sec, e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent26() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, not e3 for 1 sec, e4 with e2, e3 and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20], not Stream3[price>30] for 1 " +
+                "sec, e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent27() throws InterruptedException {
+        log.info("Test the query not e1, e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent28() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 and e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent29() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 and e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent30() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 or e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent31() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 or e4 without e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", null, "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent32() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 or e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent33() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 and e4 with e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent34() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 or e4 with e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent35() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2<2:5> with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20]<2:5> " +
+                "select e2[0].symbol as symbol0, e2[1].symbol as symbol1, e2[2].symbol as symbol2, e2[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent36() throws InterruptedException {
+        log.info("Test the query e1+, not e2 for 1 sec with 3 e1's followed by 1 sec delay");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10]+, not Stream2[price>20] for 1 sec " +
+                "select e1[0].symbol as symbol0, e1[1].symbol as symbol1, e1[2].symbol as symbol2, e1[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "WSO2", "IBM", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 25.0f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent37() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2 with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, e2=Stream2[price>20] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent38() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent39() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 or e4 with e2 followed by 1 sec delay");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] or " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"WSO2", 25.5f, 100});
+        Thread.sleep(1100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentWithEverySequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentWithEverySequenceTestCase.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.sequence.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - every A, not B for 1 sec
+ */
+public class AbsentWithEverySequenceTestCase {
+
+    private static final Logger log = Logger.getLogger(AbsentWithEverySequenceTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testQuery1() throws InterruptedException {
+        log.info("Test the query every e1, not e2 for 1 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price1 float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>20], not Stream2[price1>e1.price] for 1sec " +
+                "select e1.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOG"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQuery2() throws InterruptedException {
+        log.info("Test the query every e1, not e2 for 1 sec with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price1 float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>20], not Stream2[price1>e1.price] for 1sec " +
+                "select e1.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 55.7f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQuery3() throws InterruptedException {
+        log.info("Test the query every e1, not e2 for 1 sec, e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>20], not Stream2[price>e1.price] for 1sec, " +
+                "e3=Stream3[price>e1.price] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOG", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"GOOG", 55.6f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"IBM", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/EveryAbsentSequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/EveryAbsentSequenceTestCase.java
@@ -1,0 +1,934 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.sequence.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - 'A, every(not B for 1 sec)'
+ * - 'every (not A for 1 sec), B'
+ * - 'A, every(not B and C)'
+ * - 'every(not A and B), C'
+ * - 'A, every(not B for 1 sec and C)'
+ * - 'every(not A for 1 sec and B), C'
+ */
+public class EveryAbsentSequenceTestCase {
+
+    private static final Logger log = Logger.getLogger(EveryAbsentSequenceTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+    }
+
+    @Test
+    public void testQueryAbsent1() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2 sending e2 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent2() throws InterruptedException {
+        log.info("Test the query every not e1, e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"WSO2"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2200);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"WSO2", 68.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent3() throws InterruptedException {
+        log.info("Test the query every not e1, e2 with e1 and e2 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 59.6f, 100});
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent4() throws InterruptedException {
+        log.info("Test the query every not e1, e2 with e1 and e2 for 1 sec where e1 filter fails");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(500);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5() throws InterruptedException {
+        log.info("Test the query every not e1, e2 with e1 and e2 for 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 55.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent6() throws InterruptedException {
+        log.info("Test the query every e1, not e2 for 1 sec, e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent7() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2, e3 with e1, e2 e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2, e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent9() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2, e3 with e1 that fails to satisfy the condition, e2 " +
+                "and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 5.6f, 100});
+        Thread.sleep(600);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent10() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2, e3 with e1, e2 after 2 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent11() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, e2, e3 with e1, e2 after 2 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from  not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.6f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent12() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2, e3-> e4 with e1, e2, e3, and e4");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20], e3=Stream3[price>30], " +
+                "e4=Stream4[price>40] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.6f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 28.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 38.7f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 44.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent13() throws InterruptedException {
+        log.info("Test the query every not e1, e2 without e1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>20] for 1 sec, e2=Stream2[price>30] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 58.7f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent14() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2<2:5> with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20]<2:5> " +
+                "select e2[0].symbol as symbol0, e2[1].symbol as symbol1, e2[2].symbol as symbol2, e2[3].symbol as " +
+                "symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent15() throws InterruptedException {
+        log.info("Test the query every (e1 for 1 sec and e2), e3 with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]), e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent16() throws InterruptedException {
+        log.info("Test the query every not e1 for 1 sec, e2 with e2 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every not Stream1[price>10] for 1 sec, e2=Stream2[price>20] " +
+                "select e2.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 45.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent17() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec, e3 and e4 without e2 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec, e2=Stream3[price>30] and " +
+                "e3=Stream4[price>40]" +
+                "select e1.symbol as symbol1, e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"IBM", 18.7f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event not arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent18() throws InterruptedException {
+        log.info("Test the query every (not e1 and e2), e3 with e2 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] and e2=Stream2[price>20]), e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"WSO2", 26.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent19() throws InterruptedException {
+        log.info("Test the query every (not e1 and e2), e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] and e2=Stream2[price>20]), e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent20() throws InterruptedException {
+        log.info("Test the query every (not e1 and e2), e3 with e1, e2, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] and e2=Stream2[price>20]), e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"MICROSOFT", 28.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/LogicalAbsentSequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/LogicalAbsentSequenceTestCase.java
@@ -1,0 +1,2950 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.sequence.absent;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test the patterns:
+ * - 'A -> not B and C'
+ * - 'not A and B -> C'
+ * - 'A -> not B for 1 sec and C'
+ * - 'A -> not B for 1 sec or C'
+ * - 'A -> not B for 1 sec and not C for 1 sec'
+ * - 'A -> not B for 1 sec or not C for 1 sec'
+ * - 'not A for 1 sec and not B for 1 sec -> C'
+ * - 'not A for 1 sec or not B for 1 sec -> C'
+ */
+public class LogicalAbsentSequenceTestCase {
+
+    private static final Logger log = Logger.getLogger(LogicalAbsentSequenceTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private List<AssertionError> assertionErrors = new ArrayList<>();
+
+    @Before
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+        assertionErrors.clear();
+    }
+
+    @Test
+    public void testQueryAbsent1() throws InterruptedException {
+        log.info("Test the query e1, not e2 and e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent2() throws InterruptedException {
+        log.info("Test the query e1, not e2 and e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent3() throws InterruptedException {
+        log.info("Test the query not e1 and e2, e3 with e2 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent4() throws InterruptedException {
+        log.info("Test the query not e1 and e2, e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent5() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec and e3 with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent6() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec and e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent7() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec and e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent8() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2, e3 with e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent9() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2, e3 with e2 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent10() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2, e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent11() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec or e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent12() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec or e3 with e1 and e3 with extra 1 sec to make sure no " +
+                "duplicates");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent13() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec or e3 with e1 only with 1 sec waiting");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent14() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec or e3 with e1 only with no waiting");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent15() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec or e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent16() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec or e3 with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec or e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent17() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec or e2, e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec or e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"WSO2", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent18() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec or e2, e3 with e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec or e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent19() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec or e2, e3 with e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec or e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent20() throws InterruptedException {
+        log.info("Test the query e1, (not e2 and e3) within 1 sec with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] and e3=Stream3[price>30]) within 1 sec " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent21() throws InterruptedException {
+        log.info("Test the query e1, (not e2 and e3) within 1 sec with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] and e3=Stream3[price>30]) within 1 sec " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent22() throws InterruptedException {
+        log.info("Test the query e1, (not e2 and e3) within 1 sec with e1, e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] and e3=Stream3[price>30]) within 1 sec " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent23() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec and e3) within 2 sec with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) within 2 sec" +
+                " " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent24() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec and e3) within 2 sec with e1 and e3 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec and e3=Stream3[price>30]) within 2 sec" +
+                " " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent25() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent26() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent27() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent28() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec and not e3 for 1 sec) within 2 sec with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec and not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"ORACLE", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent29() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent30() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1 and e2");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent31() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent32() throws InterruptedException {
+        log.info("Test the query e1, (not e2 for 1 sec or not e3 for 1 sec) within 2 sec with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], (not Stream2[price>20] for 1 sec or not Stream3[price>30] for 1 sec) " +
+                "within 2 sec" +
+                " " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 101});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"ORACLE", 35.0f, 102});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent33() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec), e3 with e3 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent34() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec), e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"IBM", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent35() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec), e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent36() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec or not e2 for 1 sec), e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test
+    public void testQueryAbsent37() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec), e3 with e3 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent38() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec), e3 with e1 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"IBM", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent39() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec), e3 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent40() throws InterruptedException {
+        log.info("Test the query (not e1 for 1 sec and not e2 for 1 sec), e3 with e1, e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec), e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent41() throws InterruptedException {
+        log.info("Test the query e1, e2 or not e3 for 1 sec with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20] or not Stream3[price>30] for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"GOOGLE", 25.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent42() throws InterruptedException {
+        log.info("Test the query e1, e2 or not e3 for 1 sec with e1 only");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], e2=Stream2[price>20] or not Stream3[price>30] for 1 sec  " +
+                "select e1.symbol as symbol1, e2.symbol as symbol2 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(1100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent43() throws InterruptedException {
+        log.info("Test the query e1 or not e2 for 1 sec, e3 with e1 and e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] or not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent44() throws InterruptedException {
+        log.info("Test the query e1 or not e2 for 1 sec, e3 with e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] or not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent45() throws InterruptedException {
+        log.info("Test the query e1 or not e2 for 1 sec, e3 with e3 within 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10] or not Stream2[price>20] for 1 sec, e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        siddhiAppRuntime.start();
+
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent46() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or not e2 for 1 sec), e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(300);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(800);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent47() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or not e2 for 1 sec), e3 with two e3s");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent48() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or not e2 for 1 sec), e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or not Stream2[price>20] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent49() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and not e2 for 1 sec), e3 with two (<1 sec> e3)s");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent50() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and not e2 for 1 sec), e3 with an e3 after 2 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and not Stream2[price>20] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e3.symbol as symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent51() throws InterruptedException {
+        log.info("Test the query e1 and not e2 for 1 sec, e3 with e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e1=Stream1[price>10] and not Stream2[price>20] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"ORACLE", "MICROSOFT"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream1.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+
+        Thread.sleep(1100);
+        stream1.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"MICROSOFT", 55.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 2, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent52() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or e2), e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or e2=Stream2[price>20]), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(300);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(800);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent53() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or e2), e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or e2=Stream2[price>20]), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+                new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 3, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent54() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec or e2), e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec or e2=Stream2[price>20]), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent55() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and e2), e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(2000);
+        stream2.send(new Object[]{"WSO2", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent56() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and e2), e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent57() throws InterruptedException {
+        log.info("Test the query every (not e1 for 1 sec and e2), e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (not Stream1[price>10] for 1 sec and e2=Stream2[price>20]), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent58() throws InterruptedException {
+        log.info("Test the query every (e1 or not e2 for 1 sec), e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] or not Stream1[price>10] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(600);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(300);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(800);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent59() throws InterruptedException {
+        log.info("Test the query every (e1 or not e2 for 1 sec), e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] or not Stream1[price>10] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+                new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 3, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent60() throws InterruptedException {
+        log.info("Test the query every (e1 or not e2 for 1 sec), e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] or not Stream1[price>10] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(2100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent61() throws InterruptedException {
+        log.info("Test the query every (e1 and not e2 for 1 sec), e3 with e1, e3 and e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] and not Stream1[price>10] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"ORACLE", 15.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"MICROSOFT", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(2000);
+        stream2.send(new Object[]{"WSO2", 45.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 55.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent62() throws InterruptedException {
+        log.info("Test the query every (e1 and not e2 for 1 sec), e3 with e3, e3, e2, e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] and not Stream1[price>10] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(1200);
+        stream3.send(new Object[]{"IBM", 55.0f, 100});
+        Thread.sleep(100);
+        stream2.send(new Object[]{"ORACLE", 65.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 75.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent63() throws InterruptedException {
+        log.info("Test the query every (e1 and not e2 for 1 sec), e3 with only e3 after 2 seconds");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every (e2=Stream2[price>20] and not Stream1[price>10] for 1 sec), " +
+                "e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"WSO2", 35.0f, 100});
+        Thread.sleep(100);
+
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent64() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec, not e2 and e3, e4 with e2 and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); " +
+                "define stream Stream4 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec, not Stream2[price>20] and e3=Stream3[price>30], " +
+                "e4=Stream4[price>40]" +
+                "select e3.symbol as symbol3, e4.symbol as symbol4 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOGLE", "ORACLE"});
+
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+        InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+        stream4.send(new Object[]{"ORACLE", 45.0f, 100});
+        Thread.sleep(100);
+
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent65() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec and e3 with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(500);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(600);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent66() throws InterruptedException {
+        log.info("Test the query e1, not e2 for 1 sec and e3 with e1 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from e1=Stream1[price>10], not Stream2[price>20] for 1 sec and e3=Stream3[price>30] " +
+                "select e1.symbol as symbol1, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(1100);
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent67() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2, e3 with e2 and e3 after 1 sec");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(1100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 1, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertTrue("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQueryAbsent68() throws InterruptedException {
+        log.info("Test the query not e1 for 1 sec and e2, e3 with e1, e2 after 1 sec and e3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); " +
+                "define stream Stream2 (symbol string, price float, volume int); " +
+                "define stream Stream3 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from not Stream1[price>10] for 1 sec and e2=Stream2[price>20], e3=Stream3[price>30] " +
+                "select e2.symbol as symbol2, e3.symbol as symbol3 " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        addCallback(siddhiAppRuntime, "query1");
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
+        InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
+
+
+        siddhiAppRuntime.start();
+
+        Thread.sleep(500);
+        stream1.send(new Object[]{"WSO2", 15.0f, 100});
+        Thread.sleep(600);
+        stream2.send(new Object[]{"IBM", 25.0f, 100});
+        Thread.sleep(100);
+        stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
+        Thread.sleep(100);
+
+        for (AssertionError e : this.assertionErrors) {
+            throw e;
+        }
+        Assert.assertEquals("Number of success events", 0, inEventCount);
+        Assert.assertEquals("Number of remove events", 0, removeEventCount);
+        Assert.assertFalse("Event arrived", eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+        final int noOfExpectedEvents = expected.length;
+        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    eventArrived = true;
+
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
+                            try {
+                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
+                            } catch (AssertionError e) {
+                                assertionErrors.add(e);
+                            }
+                        }
+                    }
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+    }
+}

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/state/AbsentStreamStateElement.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/state/AbsentStreamStateElement.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.query.api.execution.query.input.state;
+
+import org.wso2.siddhi.query.api.execution.query.input.stream.BasicSingleInputStream;
+import org.wso2.siddhi.query.api.expression.constant.TimeConstant;
+
+/**
+ * Absent state element used in pattern to handle not operations.
+ */
+public class AbsentStreamStateElement extends StreamStateElement {
+
+    private TimeConstant waitingTime;
+
+    public AbsentStreamStateElement(BasicSingleInputStream basicSingleInputStream) {
+        super(basicSingleInputStream);
+    }
+
+    public AbsentStreamStateElement(BasicSingleInputStream basicSingleInputStream, TimeConstant within) {
+        super(basicSingleInputStream, within);
+    }
+
+    public AbsentStreamStateElement waitingTime(TimeConstant waitingTime) {
+        this.waitingTime = waitingTime;
+        return this;
+    }
+
+    public TimeConstant getWaitingTime() {
+        return waitingTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        AbsentStreamStateElement that = (AbsentStreamStateElement) o;
+
+        return waitingTime != null ? waitingTime.equals(that.waitingTime) : that.waitingTime == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (waitingTime != null ? waitingTime.hashCode() : 0);
+        return result;
+    }
+}

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/state/LogicalStateElement.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/state/LogicalStateElement.java
@@ -119,7 +119,6 @@ public class LogicalStateElement implements StateElement {
      */
     public enum Type {
         AND,
-        OR,
-        NOT
+        OR
     }
 }

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/state/State.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/state/State.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.siddhi.query.api.execution.query.input.state;
 
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 import org.wso2.siddhi.query.api.execution.query.input.stream.BasicSingleInputStream;
 import org.wso2.siddhi.query.api.expression.constant.TimeConstant;
 
@@ -54,21 +55,39 @@ public class State {
         return new LogicalStateElement(streamStateElement1, LogicalStateElement.Type.OR, streamStateElement2, time);
     }
 
-    public static StateElement logicalNot(StreamStateElement notStreamStateElement,
-                                          TimeConstant time) {
-        return new LogicalStateElement(null, LogicalStateElement.Type.NOT, notStreamStateElement, time);
+    public static AbsentStreamStateElement logicalNot(StreamStateElement streamStateElement) {
+        if (streamStateElement.getBasicSingleInputStream().getStreamReferenceId() != null) {
+            throw new SiddhiAppValidationException("NOT pattern cannot have reference id but found " +
+                    streamStateElement.getBasicSingleInputStream().getStreamReferenceId());
+        }
+        return new AbsentStreamStateElement(streamStateElement.getBasicSingleInputStream());
     }
 
-    public static StateElement logicalNotAnd(StreamStateElement notStreamStateElement,
-                                             StreamStateElement andStreamStateElement,
-                                             TimeConstant time) {
-        return new LogicalStateElement(andStreamStateElement, LogicalStateElement.Type.NOT, notStreamStateElement,
-                time);
+    public static AbsentStreamStateElement logicalNot(StreamStateElement streamStateElement, TimeConstant time) {
+        if (streamStateElement.getBasicSingleInputStream().getStreamReferenceId() != null) {
+            throw new SiddhiAppValidationException("NOT pattern cannot have reference id but found " +
+                    streamStateElement.getBasicSingleInputStream().getStreamReferenceId());
+        }
+        return new AbsentStreamStateElement(streamStateElement.getBasicSingleInputStream(), time);
     }
 
-    public static StateElement logicalNotAnd(StreamStateElement notStreamStateElement,
-                                             StreamStateElement andStreamStateElement) {
-        return new LogicalStateElement(andStreamStateElement, LogicalStateElement.Type.NOT, notStreamStateElement);
+    public static StateElement logicalNotAnd(StreamStateElement streamStateElement1,
+                                             AbsentStreamStateElement streamStateElement2) {
+
+        if (streamStateElement1 instanceof AbsentStreamStateElement) {
+            // not A for 1 sec and not B for 1 sec
+            return new LogicalStateElement(streamStateElement1, LogicalStateElement.Type.AND,
+                    streamStateElement2);
+        }
+        if (streamStateElement2.getWaitingTime() == null) {
+            // not A and B
+            return new LogicalStateElement(streamStateElement1, LogicalStateElement.Type.AND,
+                    streamStateElement2);
+        } else {
+            // not A for 1 sec and B
+            return new LogicalStateElement(streamStateElement2, LogicalStateElement.Type.AND,
+                    streamStateElement1);
+        }
     }
 
     public static StateElement next(StateElement stateElement,

--- a/modules/siddhi-query-compiler/src/test/java/org/wso2/siddhi/query/test/AbsentPatternTestCase.java
+++ b/modules/siddhi-query-compiler/src/test/java/org/wso2/siddhi/query/test/AbsentPatternTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.query.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.siddhi.query.api.execution.query.Query;
+import org.wso2.siddhi.query.api.execution.query.input.state.State;
+import org.wso2.siddhi.query.api.execution.query.input.stream.InputStream;
+import org.wso2.siddhi.query.api.execution.query.selection.Selector;
+import org.wso2.siddhi.query.api.expression.Expression;
+import org.wso2.siddhi.query.api.expression.condition.Compare;
+import org.wso2.siddhi.query.api.expression.constant.TimeConstant;
+import org.wso2.siddhi.query.compiler.SiddhiCompiler;
+import org.wso2.siddhi.query.compiler.exception.SiddhiParserException;
+
+public class AbsentPatternTestCase {
+
+    @Test(expected = SiddhiParserException.class)
+    public void test1() throws SiddhiParserException {
+
+        SiddhiCompiler.parseQuery("from e1=Stream1[price>20] -> not Stream2[price>e1.price] " +
+                "select e1.symbol as symbol, e1.price as price " +
+                "insert into OutputStream ;");
+    }
+
+    @Test(expected = SiddhiParserException.class)
+    public void test2() throws SiddhiParserException {
+
+        SiddhiCompiler.parseQuery("from e1=Stream1[price>20] -> not e2=Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol, e1.price as price " +
+                "insert into OutputStream ;");
+    }
+
+    @Test(expected = SiddhiParserException.class)
+    public void test3() throws SiddhiParserException {
+
+        SiddhiCompiler.parseQuery("from not Stream1[price>20] for 1 sec -> not Stream2[price>e1.price] for 1 sec " +
+                "select e1.symbol as symbol, e1.price as price " +
+                "insert into OutputStream ;");
+    }
+
+    @Test
+    public void test4() throws SiddhiParserException {
+        Query query = SiddhiCompiler.parseQuery("from e1=Stream1[price>20] -> not Stream2[price>e1.price] for 2 sec " +
+                "select e1.symbol as symbol1 " +
+                "insert into OutputStream ;");
+        Assert.assertNotNull(query);
+
+        Query api = Query.query();
+        api.from(
+                InputStream.patternStream(State.next(
+                        State.stream(InputStream.stream("e1", "Stream1")
+                                .filter(Expression.compare(Expression.variable("price"),
+                                        Compare.Operator.GREATER_THAN,
+                                        Expression.value(20)))),
+                        State.logicalNot(State.stream(InputStream.stream("Stream2")
+                                .filter(Expression.compare(Expression.variable("price"),
+                                        Compare.Operator.GREATER_THAN,
+                                        Expression.variable("price").ofStream("e1")))))
+                                .waitingTime(new TimeConstant(2000)))
+                ))
+                .select(Selector.selector().select("symbol1", Expression.variable("symbol").ofStream("e1")))
+                .insertInto("OutputStream");
+
+        Assert.assertEquals(api, query);
+    }
+
+}


### PR DESCRIPTION
This PR contains the implementation of Siddhi pattern to detect the absence of events.

**Sample cases:**
- `A -> not B for 1sec`
- `A -> not B and C`
- `A -> (not B and C) within 1sec`
- `A -> (not B for 1sec  and C) within 2sec`
- `not A for 1sec -> B`
- `not A and B -> C`
- `every ( not B and  A)  -> C`
- `every ( not B for 1sec)  -> C`
- `A -> not B  for 1 sec and not C for 1 sec`
- `not A  for 1 sec and not B for 1 sec -> C`
- `A -> not B   for 1 sec or not C for 1 sec`
- `not A  for 1 sec or not B for 1 sec -> C`
- `A -> not B for 1 sec or C`
- `not A for 1 sec or B -> C`