### PR TITLE
Update siddhi-doc-gen plugin templates

### DIFF
--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/commons/metadata/ExtensionType.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/commons/metadata/ExtensionType.java
@@ -33,11 +33,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Enum for holding extension types supported by the doc generator
+ * Enum for holding extension types supported by the doc generator and the free marker templates
+ *
+ * The enum values should be changed to match the names used in the documentation
+ * The enum values will affect the names used in the documentation as well as the hyperlinks
+ *
+ * These enum values will be passed onto the freemarker templates as a map
+ * The other members of the enum class will not be accessible from the freemarker templates
+ * These can be accesses using the EXTENSION_TYPE variable
+ * eg:- EXTENSION_TYPE.FUNCTION
  */
 public enum ExtensionType {
     FUNCTION("Function"),
-    ATTRIBUTE_AGGREGATOR("Attribute Aggregator"),
+    ATTRIBUTE_AGGREGATOR("Aggregate Function"),
     WINDOW("Window"),
     STREAM_FUNCTION("Stream Function"),
     STREAM_PROCESSOR("Stream Processor"),
@@ -46,7 +54,7 @@ public enum ExtensionType {
     SOURCE_MAPPER("Source Mapper"),
     SINK_MAPPER("Sink Mapper"),
     STORE("Store"),
-    SCRIPT("Script");
+    SCRIPT("Eval Script");
 
     /**
      * Contains the name to be displayed as the extension type

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/ExtensionsIndexGenerationMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/ExtensionsIndexGenerationMojo.java
@@ -90,11 +90,11 @@ public class ExtensionsIndexGenerationMojo extends AbstractMojo {
         }
 
         // Setting the documentation output directory if not set by user
-        String docGenPath;
+        String docGenBasePath;
         if (docGenBaseDirectory != null) {
-            docGenPath = docGenBaseDirectory.getAbsolutePath();
+            docGenBasePath = docGenBaseDirectory.getAbsolutePath();
         } else {
-            docGenPath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
+            docGenBasePath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
         }
 
         // Setting the documentation output file name if not set by user
@@ -104,7 +104,7 @@ public class ExtensionsIndexGenerationMojo extends AbstractMojo {
 
         // Creating a extensions index
         DocumentationUtils.createExtensionsIndex(
-                extensionRepositories, extensionRepositoryOwner, docGenPath, indexGenFileName, getLog()
+                extensionRepositories, extensionRepositoryOwner, docGenBasePath, indexGenFileName
         );
     }
 }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MarkdownDocumentationGenerationMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MarkdownDocumentationGenerationMojo.java
@@ -101,11 +101,11 @@ public class MarkdownDocumentationGenerationMojo extends AbstractMojo {
         }
 
         // Setting the documentation output directory if not set by user
-        String docGenPath;
+        String docGenBasePath;
         if (docGenBaseDirectory != null) {
-            docGenPath = docGenBaseDirectory.getAbsolutePath();
+            docGenBasePath = docGenBaseDirectory.getAbsolutePath();
         } else {
-            docGenPath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
+            docGenBasePath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
         }
 
         // Setting the read me file path if not set by user
@@ -139,9 +139,8 @@ public class MarkdownDocumentationGenerationMojo extends AbstractMojo {
 
         // Generating the documentation
         if (namespaceMetaDataList.size() > 0) {
-            DocumentationUtils.generateDocumentation(namespaceMetaDataList, docGenPath,
-                    mavenProject.getVersion(), getLog());
-            DocumentationUtils.updateHomePage(homePageTemplateFile, docGenPath,
+            DocumentationUtils.generateDocumentation(namespaceMetaDataList, docGenBasePath, mavenProject.getVersion());
+            DocumentationUtils.updateHomePage(homePageTemplateFile, docGenBasePath,
                     homePageFileName, mkdocsConfigFile, getLog());
         }
     }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MarkdownDocumentationGenerationMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MarkdownDocumentationGenerationMojo.java
@@ -140,8 +140,8 @@ public class MarkdownDocumentationGenerationMojo extends AbstractMojo {
         // Generating the documentation
         if (namespaceMetaDataList.size() > 0) {
             DocumentationUtils.generateDocumentation(namespaceMetaDataList, docGenBasePath, mavenProject.getVersion());
-            DocumentationUtils.updateHomePage(homePageTemplateFile, docGenBasePath,
-                    homePageFileName, mkdocsConfigFile, getLog());
+            DocumentationUtils.updateHomePage(homePageTemplateFile, docGenBasePath, homePageFileName, mkdocsConfigFile,
+                    mavenProject.getVersion(), namespaceMetaDataList, getLog());
         }
     }
 }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MkdocsGitHubPagesDeployMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MkdocsGitHubPagesDeployMojo.java
@@ -73,15 +73,16 @@ public class MkdocsGitHubPagesDeployMojo extends AbstractMojo {
         }
 
         // Setting the documentation output directory if not set by user
-        String docGenPath;
+        String docGenBasePath;
         if (docGenBaseDirectory != null) {
-            docGenPath = docGenBaseDirectory.getAbsolutePath();
+            docGenBasePath = docGenBaseDirectory.getAbsolutePath();
         } else {
-            docGenPath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
+            docGenBasePath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
         }
 
+        DocumentationUtils.removeSnapshotAPIDocs(mkdocsConfigFile, docGenBasePath, getLog());
         DocumentationUtils.deployMkdocsOnGitHubPages(mkdocsConfigFile, getLog());
-        DocumentationUtils.updateDocumentationOnGitHub(docGenPath, mkdocsConfigFile,
+        DocumentationUtils.updateDocumentationOnGitHub(docGenBasePath, mkdocsConfigFile,
                 mavenProject.getVersion(), getLog());
     }
 }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MkdocsGitHubPagesDeployMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MkdocsGitHubPagesDeployMojo.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.siddhi.doc.gen.core;
 
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -24,10 +25,12 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.wso2.siddhi.doc.gen.commons.metadata.NamespaceMetaData;
 import org.wso2.siddhi.doc.gen.core.utils.Constants;
 import org.wso2.siddhi.doc.gen.core.utils.DocumentationUtils;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Mojo for deploying mkdocs website on GitHub pages
@@ -58,6 +61,27 @@ public class MkdocsGitHubPagesDeployMojo extends AbstractMojo {
     @Parameter(property = "doc.gen.base.directory")
     private File docGenBaseDirectory;
 
+    /**
+     * The path of the readme file in the base directory
+     * Optional
+     */
+    @Parameter(property = "home.page.template.file")
+    private File homePageTemplateFile;
+
+    /**
+     * The name of the index file
+     * Optional
+     */
+    @Parameter(property = "home.page.file.name")
+    private String homePageFileName;
+
+    /**
+     * The target module for which the files will be generated
+     * Optional
+     */
+    @Parameter(property = "module.target.directory")
+    private File moduleTargetDirectory;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         // Finding the root maven project
@@ -80,8 +104,46 @@ public class MkdocsGitHubPagesDeployMojo extends AbstractMojo {
             docGenBasePath = rootMavenProject.getBasedir() + File.separator + Constants.DOCS_DIRECTORY;
         }
 
+        // Setting the read me file path if not set by user
+        if (homePageTemplateFile == null) {
+            homePageTemplateFile = new File(rootMavenProject.getBasedir() + File.separator
+                    + Constants.README_FILE_NAME + Constants.MARKDOWN_FILE_EXTENSION);
+        }
+
+        // Setting the index file name if not set by user
+        if (homePageFileName == null) {
+            homePageFileName = Constants.MARKDOWN_HOME_PAGE_TEMPLATE;
+        }
+
+        // Setting the relevant modules target directory if not set by user
+        String moduleTargetPath;
+        if (moduleTargetDirectory != null) {
+            moduleTargetPath = moduleTargetDirectory.getAbsolutePath();
+        } else {
+            moduleTargetPath = mavenProject.getBuild().getDirectory();
+        }
+
+        // Retrieving metadata
+        List<NamespaceMetaData> namespaceMetaDataList;
+        try {
+            namespaceMetaDataList = DocumentationUtils.getExtensionMetaData(
+                    moduleTargetPath,
+                    mavenProject.getRuntimeClasspathElements(),
+                    getLog()
+            );
+        } catch (DependencyResolutionRequiredException e) {
+            throw new MojoFailureException("Unable to resolve dependencies of the project", e);
+        }
+
+        // Updating the documentation
         DocumentationUtils.removeSnapshotAPIDocs(mkdocsConfigFile, docGenBasePath, getLog());
-        DocumentationUtils.deployMkdocsOnGitHubPages(mkdocsConfigFile, getLog());
+        if (namespaceMetaDataList.size() > 0) {
+            DocumentationUtils.updateHomePage(homePageTemplateFile, docGenBasePath, homePageFileName, mkdocsConfigFile,
+                    mavenProject.getVersion(), namespaceMetaDataList, getLog());
+        }
+
+        // Deploying the documentation
+        DocumentationUtils.deployMkdocsOnGitHubPages(mkdocsConfigFile, mavenProject.getVersion(), getLog());
         DocumentationUtils.updateDocumentationOnGitHub(docGenBasePath, mkdocsConfigFile,
                 mavenProject.getVersion(), getLog());
     }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
@@ -66,4 +66,5 @@ public class Constants {
 
     public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     public static final String CORE_NAMESPACE = "core";
+    public static final String SNAPSHOT_VERSION_POSTFIX = "-SNAPSHOT";
 }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
@@ -21,7 +21,11 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Constants used by the doc generator
+ * Constants used by the doc generator and the free marker templates
+ *
+ * These constants will be passed onto the freemarker templates as a map
+ * These can be accesses using the CONSTANTS variable
+ * eg:- CONSTANTS.DOCS_DIRECTORY
  */
 public class Constants {
     public static final String DOCS_DIRECTORY = "docs";
@@ -51,20 +55,28 @@ public class Constants {
 
     public static final String MKDOCS_COMMAND = "mkdocs";
     public static final String MKDOCS_GITHUB_DEPLOY_COMMAND = "gh-deploy";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_CONFIG_FILE_ARGUMENT = "--config-file";
+    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_CONFIG_FILE_ARGUMENT = "-f";
+    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_MESSAGE_ARGUMENT = "-m";
 
     public static final String GIT_COMMAND = "git";
     public static final String GIT_ADD_COMMAND = "add";
+    public static final String GIT_PUSH_COMMAND = "push";
+    public static final String GIT_PUSH_COMMAND_REMOTE = "origin";
+    public static final String GIT_PUSH_COMMAND_REMOTE_BRANCH = "master";
     public static final String GIT_COMMIT_COMMAND = "commit";
     public static final String GIT_COMMIT_COMMAND_FILES_ARGUMENT = "--";
     public static final String GIT_COMMIT_COMMAND_MESSAGE_ARGUMENT = "-m";
     public static final String GIT_COMMIT_COMMAND_MESSAGE_FORMAT = "[WSO2-Release] [Release %s] " +
             "update documentation for release %s";
-    public static final String GIT_PUSH_COMMAND = "push";
-    public static final String GIT_PUSH_COMMAND_REMOTE = "origin";
-    public static final String GIT_PUSH_COMMAND_REMOTE_BRANCH = "master";
 
     public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     public static final String CORE_NAMESPACE = "core";
     public static final String SNAPSHOT_VERSION_POSTFIX = "-SNAPSHOT";
+
+    /*
+     * Constants used by freemarker templates
+     */
+    public static final String FREEMARKER_FEATURES_HEADING = "## Features";
+    public static final String FREEMARKER_LATEST_API_DOCS_HEADING = "## Latest API Docs";
+    public static final String FREEMARKER_SIDDHI_HOME_PAGE = "https://wso2.github.io/siddhi";
 }

--- a/modules/siddhi-doc-gen/src/main/resources/templates/documentation.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/documentation.md.ftl
@@ -15,6 +15,7 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+<#import "utils.ftl" as utils>
 # API Docs
 
 <#list metaData as namespace>
@@ -22,47 +23,53 @@
 
 <#list namespace.extensionMap as extensionType, extensionsList>
 <#list extensionsList as extension>
-### ${extension.name} _(${extensionType})_
+### ${extension.name} *(<@utils.renderLinkToExtensionTypeDoc extensionType=extensionType/>)*
 
 <p style="word-wrap: break-word">${formatDescription(extension.description)}</p>
 
-#### Syntax
+<@utils.renderHeadingFourWithStylesOnly heading="Syntax"/>
 
-<#if ["Function", "Attribute Aggregator"]?seq_index_of(extensionType) != -1>
+<#if [EXTENSION_TYPE.FUNCTION, EXTENSION_TYPE.ATTRIBUTE_AGGREGATOR]?seq_index_of(extensionType) != -1>
 ```
-<#if extension.returnAttributes??><#list extension.returnAttributes><<#items as returnAttribute>${returnAttribute.type?join("|", "")}</#items>> </#list></#if>${extension.name}(<#list extension.parameters><#items as parameter><${parameter.type?join("|", "")}> ${parameter.name}<#sep>, </#items></#list>)
+<#if extension.returnAttributes??><#list extension.returnAttributes><<#items as returnAttribute>${returnAttribute.type?join("|", "")}</#items>> </#list></#if><#if namespace.name != CONSTANTS.CORE_NAMESPACE>${namespace.name}:</#if>${extension.name}(<#list extension.parameters><#items as parameter><${parameter.type?join("|", "")}> ${parameter.name}<#sep>, </#items></#list>)
 ```
-<#elseif ["Stream Processor", "Stream Function", "Window"]?seq_index_of(extensionType) != -1>
+<#elseif [EXTENSION_TYPE.STREAM_PROCESSOR, EXTENSION_TYPE.STREAM_FUNCTION, EXTENSION_TYPE.WINDOW]?seq_index_of(extensionType) != -1>
 ```
-${extension.name}(<#list extension.parameters><#items as parameter><${parameter.type?join("|", "")}> ${parameter.name}<#sep>, </#items></#list>)
+<#if namespace.name != CONSTANTS.CORE_NAMESPACE>${namespace.name}:</#if>${extension.name}(<#list extension.parameters><#items as parameter><${parameter.type?join("|", "")}> ${parameter.name}<#sep>, </#items></#list>)
 ```
-<#elseif ["Source", "Sink"]?seq_index_of(extensionType) != -1>
+<#elseif [EXTENSION_TYPE.SOURCE, EXTENSION_TYPE.SINK]?seq_index_of(extensionType) != -1>
 ```
 @${extensionType?lower_case}(type="${extension.name}"<#list extension.parameters as parameter>, ${parameter.name}="<${parameter.type?join("|", "")}>"</#list>, @map(...)))
 ```
-<#elseif extensionType == "Source Mapper">
+<#elseif extensionType == EXTENSION_TYPE.SOURCE_MAPPER>
 ```
 @source(..., @map(type="${extension.name}"<#list extension.parameters as parameter>, ${parameter.name}="<${parameter.type?join("|", "")}>"</#list>)
 ```
-<#elseif extensionType == "Sink Mapper">
+<#elseif extensionType == EXTENSION_TYPE.SINK_MAPPER>
 ```
 @sink(..., @map(type="${extension.name}"<#list extension.parameters as parameter>, ${parameter.name}="<${parameter.type?join("|", "")}>"</#list>)
 ```
-<#elseif extensionType == "Store">
+<#elseif extensionType == EXTENSION_TYPE.STORE>
 ```
 @Store(type="${extension.name}"<#list extension.parameters as parameter>, ${parameter.name}="<${parameter.type?join("|", "")}>"</#list>)
 @PrimaryKey("PRIMARY_KEY")
 @Index("INDEX")
 ```
+<#elseif extensionType == EXTENSION_TYPE.SCRIPT>
+```
+define function <evalFunctionName>[${extension.name}] return <type> {
+    // Eval script code
+};
+```
 </#if>
-
 <#list extension.parameters>
-##### Query Parameters
+
+<@utils.renderHeadingFiveWithStylesOnly heading="Query Parameters"/>
 
 <table>
     <tr>
         <th>Name</th>
-        <th style="min-width:20em">Description</th>
+        <th style="min-width: 20em">Description</th>
         <th>Default Value</th>
         <th>Possible Data Types</th>
         <th>Optional</th>
@@ -80,14 +87,14 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
     </#items>
 </table>
 </#list>
-
 <#list extension.systemParameters>
-#### System Parameters
+
+<@utils.renderHeadingFourWithStylesOnly heading="System Parameters"/>
 
 <table>
     <tr>
         <th>Name</th>
-        <th style="min-width:20em">Description</th>
+        <th style="min-width: 20em">Description</th>
         <th>Default Value</th>
         <th>Possible Parameters</th>
     </tr>
@@ -101,15 +108,14 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
     </#items>
 </table>
 </#list>
-
-<#if ["Stream Processor", "Stream Function"]?seq_index_of(extensionType) != -1>
+<#if [EXTENSION_TYPE.STREAM_PROCESSOR, EXTENSION_TYPE.STREAM_FUNCTION]?seq_index_of(extensionType) != -1>
 <#list extension.returnAttributes>
-#### Extra Return Attributes
+<@utils.renderHeadingFourWithStylesOnly heading="Extra Return Attributes"/>
 
 <table>
     <tr>
         <th>Name</th>
-        <th style="min-width:20em">Description</th>
+        <th style="min-width: 20em">Description</th>
         <th>Possible Types</th>
     </tr>
     <#items as returnAttribute>
@@ -124,10 +130,10 @@ ${extension.name}(<#list extension.parameters><#items as parameter><${parameter.
 </#if>
 
 <#list extension.examples>
-#### Examples
+<@utils.renderHeadingFourWithStylesOnly heading="Examples"/>
 
 <#items as example>
-##### Example ${example?index + 1}
+<@utils.renderHeadingFiveWithStylesOnly heading=("Example" + (example?index + 1))/>
 
 ```
 ${example.syntax}

--- a/modules/siddhi-doc-gen/src/main/resources/templates/extensions.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/extensions.md.ftl
@@ -1,3 +1,20 @@
+<#--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 # Siddhi Extensions
 
 ## Available Extensions
@@ -8,7 +25,7 @@ Siddhi currently have several prewritten extensions as follows;
 <#list extensionRepositories>
 ### ${title}
 <#items as extensionRepository>
-1. <a target="_blank" href="https://${extensionsOwner}.github.io/${extensionRepository}">${extensionRepository?replace("^siddhi-gpl-", "", "rf")?replace("^siddhi-", "", "rf")?replace("-", " ")}</a>
+1. <a target="_blank" href="https://${extensionsOwner}.github.io/${extensionRepository}">${extensionRepository?replace(CONSTANTS.GITHUB_GPL_EXTENSION_REPOSITORY_PREFIX, "", "rf")?replace(CONSTANTS.GITHUB_APACHE_EXTENSION_REPOSITORY_PREFIX, "", "rf")?replace("-", " ")}</a>
 </#items>
 </#list>
 
@@ -18,4 +35,4 @@ Siddhi currently have several prewritten extensions as follows;
 
 ## Extension Repositories
 
-All the extension repositories maintained by WSO2 can be found <a target="_blank" href="https://github.com/wso2-extensions/?utf8=%E2%9C%93&q=siddhi&type=&language=">here</a>
+All the extension repositories maintained by WSO2 can be found <a target="_blank" href="https://github.com/${extensionsOwner}/?utf8=%E2%9C%93&q=siddhi&type=&language=">here</a>

--- a/modules/siddhi-doc-gen/src/main/resources/templates/index.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/index.md.ftl
@@ -1,11 +1,51 @@
-<#list readMeFileLines as readMeFileLine>
-${readMeFileLine}
+<#--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<#import "utils.ftl" as utils>
+<#assign skipMaxHeadingLevel = -1>
+<#macro renderLine line>
+${line}
+<#if line?starts_with(CONSTANTS.FREEMARKER_FEATURES_HEADING)>
+<#assign skipMaxHeadingLevel = line?index_of(" ")>
+
+<#if metaData??>
+<#list metaData as namespace>
+<#list namespace.extensionMap as extensionType, extensionsList>
+<#list extensionsList as extension>
+* <a target="_blank" href="./api/${latestDocumentationVersion}/#<@utils.getHTMLIDForHeading heading=(extension.name + "-" + extensionType)/>">${extension.name}</a> *(<@utils.renderLinkToExtensionTypeDoc extensionType=extensionType/>)*<br><div style="padding-left: 1em;"><p>${formatDescription(extension.description)}</p></div>
 </#list>
-
-## API Docs
-
-<#if documentationFiles??>
-<#list documentationFiles as documentationFile>
-1. <a href="./api/${documentationFile?remove_ending(".md")}">${documentationFile?remove_ending(".md")}</a>
+</#list>
+<#else>
+No Features Currently Available
 </#list>
 </#if>
+
+<#elseif line?starts_with(CONSTANTS.FREEMARKER_LATEST_API_DOCS_HEADING)>
+<#assign skipMaxHeadingLevel = line?index_of(" ")>
+
+Latest API Docs is <a target="_blank" href="./api/${latestDocumentationVersion}">${latestDocumentationVersion}</a>.
+
+</#if>
+</#macro>
+<#list homePageTemplateFileLines as homePageTemplateFileLine>
+<#if skipMaxHeadingLevel == -1>
+<@renderLine line=homePageTemplateFileLine/>
+<#elseif homePageTemplateFileLine?starts_with("#") && skipMaxHeadingLevel gte homePageTemplateFileLine?index_of(" ")>
+<#assign skipMaxHeadingLevel = -1>
+<@renderLine line=homePageTemplateFileLine/>
+</#if>
+</#list>

--- a/modules/siddhi-doc-gen/src/main/resources/templates/utils.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/utils.ftl
@@ -1,0 +1,30 @@
+<#--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<#macro getHTMLIDForHeading heading>${heading?lower_case?replace(" ", "-", "r")}</#macro>
+
+<#macro renderLinkToExtensionTypeDoc extensionType><a target="_blank" href="${CONSTANTS.FREEMARKER_SIDDHI_HOME_PAGE}/documentation/siddhi-4.0/#<@getHTMLIDForHeading heading=extensionType/>s">${extensionType}</a></#macro>
+
+<#macro renderHeadingOneWithStylesOnly heading><span id="<@getHTMLIDForHeading heading=heading/>" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 31.25px; font-weight: 300; margin: 0 0 40px 0">${heading}</span></#macro>
+
+<#macro renderHeadingTwoWithStylesOnly heading><span id="<@getHTMLIDForHeading heading=heading/>" class="md-typeset" style="display: block; font-size: 25px; font-weight: 300; margin: 40px 0 16px 0">${heading}</span></#macro>
+
+<#macro renderHeadingThreeWithStylesOnly heading><span id="<@getHTMLIDForHeading heading=heading/>" class="md-typeset" style="display: block; font-size: 20px;">${heading}</span></#macro>
+
+<#macro renderHeadingFourWithStylesOnly heading><span id="<@getHTMLIDForHeading heading=heading/>" class="md-typeset" style="display: block; font-weight: bold;">${heading}</span></#macro>
+
+<#macro renderHeadingFiveWithStylesOnly heading><span id="<@getHTMLIDForHeading heading=heading/>" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">${heading?upper_case}</span></#macro>


### PR DESCRIPTION
This PR contains the following

* Remove all  x.x.x-SNAPSHOT when doing release perform
* Support for adding "## Features" heading in the homePageTemplate file which will be replaced by a list of API Doc extensions
* Support for adding "## Latest API Docs" heading in the homePageTemplate file which will be replaced by the main API Docs version
* Add "namespace:" in syntax of Function, Attribute Aggregator, Window, Stream Function & Stream Processor
* Change from heading to normal text with same style for Sytex, Query Parameters, Example etc (Other than for the API Names)
* Link to type function doc in Siddhi Doc from the "type" of "Name(type)" heading of each API Name.
* Add syntax for Script