### PR TITLE
Siddhi Doc Gen Plugin - change the mkdocs gh-deploy to a manual git push

### DIFF
--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MkdocsGitHubPagesDeployMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MkdocsGitHubPagesDeployMojo.java
@@ -97,8 +97,11 @@ public class MkdocsGitHubPagesDeployMojo extends AbstractMojo {
         DocumentationUtils.removeSnapshotAPIDocs(mkdocsConfigFile, docGenBasePath, getLog());
 
         // Deploying the documentation
-        DocumentationUtils.deployMkdocsOnGitHubPages(mkdocsConfigFile, mavenProject.getVersion(), getLog());
-        DocumentationUtils.updateDocumentationOnGitHub(docGenBasePath, mkdocsConfigFile, readmeFile,
-                mavenProject.getVersion(), getLog());
+        if (DocumentationUtils.generateMkdocsSite(mkdocsConfigFile, getLog())) {
+            DocumentationUtils.updateDocumentationOnGitHub(docGenBasePath, mkdocsConfigFile, readmeFile,
+                    mavenProject.getVersion(), getLog());
+            DocumentationUtils.deployMkdocsOnGitHubPages(mavenProject.getVersion(), rootMavenProject.getBasedir(),
+                    getLog());
+        }
     }
 }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
@@ -48,30 +48,36 @@ public class Constants {
 
     public static final String GITHUB_GPL_EXTENSION_REPOSITORY_PREFIX = "siddhi-gpl-";
     public static final String GITHUB_APACHE_EXTENSION_REPOSITORY_PREFIX = "siddhi-";
-    public static final String GITHUB_EXTENSION_REPOSITORY_PARENT_POSTFIX = "-parent";
     public static final String GITHUB_OWNER_WSO2_EXTENSIONS = "wso2-extensions";
 
     public static final String MKDOCS_CONFIG_PAGES_KEY = "pages";
     public static final String MKDOCS_CONFIG_PAGES_API_KEY = "API Docs";
     public static final String MKDOCS_FILE_SEPARATOR = "/";
+    public static final String MKDOCS_SITE_DIRECTORY = "site";
 
     public static final String MKDOCS_COMMAND = "mkdocs";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND = "gh-deploy";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_CONFIG_FILE_ARGUMENT = "-f";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_MESSAGE_ARGUMENT = "-m";
+    public static final String MKDOCS_BUILD_COMMAND = "build";
+    public static final String MKDOCS_BUILD_COMMAND_CLEAN_ARGUEMENT = "-c";
+    public static final String MKDOCS_BUILD_COMMAND_CONFIG_FILE_ARGUMENT = "-f";
+    public static final String MKDOCS_BUILD_COMMAND_SITE_DIRECTORY_ARGUMENT = "-d";
+
+    public static final String GIT_REMOTE = "origin";
+    public static final String GIT_MASTER_BRANCH = "master";
+    public static final String GIT_GH_PAGES_BRANCH = "gh-pages";
 
     public static final String GIT_COMMAND = "git";
+    public static final String GIT_STASH_COMMAND = "stash";
+    public static final String GIT_STASH_POP_COMMAND = "pop";
     public static final String GIT_ADD_COMMAND = "add";
+    public static final String GIT_PULL_COMMAND = "pull";
     public static final String GIT_PUSH_COMMAND = "push";
-    public static final String GIT_PUSH_COMMAND_REMOTE = "origin";
-    public static final String GIT_PUSH_COMMAND_REMOTE_BRANCH = "master";
+    public static final String GIT_CHECKOUT_COMMAND = "checkout";
+    public static final String GIT_CHECKOUT_COMMAND_ORPHAN_ARGUMENT = "--orphan";
     public static final String GIT_COMMIT_COMMAND = "commit";
     public static final String GIT_COMMIT_COMMAND_FILES_ARGUMENT = "--";
     public static final String GIT_COMMIT_COMMAND_MESSAGE_ARGUMENT = "-m";
     public static final String GIT_COMMIT_COMMAND_MESSAGE_FORMAT = "[WSO2-Release] [Release %s] " +
             "update documentation for release %s";
-
-    public static final String URL_PREFIX_BASE = ".";
 
     public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     public static final String CORE_NAMESPACE = "core";
@@ -84,4 +90,5 @@ public class Constants {
     public static final String FREEMARKER_LATEST_API_DOCS_HEADING = "## Latest API Docs";
     public static final String FREEMARKER_SIDDHI_HOME_PAGE = "https://wso2.github.io/siddhi";
     public static final String FREEMARKER_SIDDHI_REPOSITORY_ARTIFACT_ID = "siddhi";
+    public static final String FREEMARKER_EXTENSION_REPOSITORY_PARENT_POSTFIX = "-parent";
 }

--- a/modules/siddhi-doc-gen/src/main/resources/templates/headings-update.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/headings-update.md.ftl
@@ -21,7 +21,7 @@
     <#assign repositoryOwner = "wso2">
 <#else>
     <#assign repositoryOwner = "wso2-extensions">
-    <#assign extensionRepositoryName = extensionRepositoryName?replace(CONSTANTS.GITHUB_EXTENSION_REPOSITORY_PARENT_POSTFIX, "", "r")>
+    <#assign extensionRepositoryName = extensionRepositoryName?replace(CONSTANTS.FREEMARKER_EXTENSION_REPOSITORY_PARENT_POSTFIX, "", "r")>
 </#if>
 <#macro renderLine line>
 ${line}


### PR DESCRIPTION
This PR contains the following changes
* Remove the mkdocs gh-deploy command execution
* Add mkdocs build command execution to build the documentation
* Add git commands to deploy the documentation to github pages