### PR TITLE
Modifying Siddhi Query API Annotation

### DIFF
--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/annotation/Annotation.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/annotation/Annotation.java
@@ -112,7 +112,7 @@ public class Annotation implements SiddhiElement {
         boolean isFirst = true;
         StringBuilder definitionBuilder = new StringBuilder("@").append(name).append("( ");
         if (elements != null && elements.size() > 0) {
-          //  boolean isFirst = true;
+
             for (Element element : elements) {
                 if (!isFirst) {
                     definitionBuilder.append(", ");
@@ -123,7 +123,7 @@ public class Annotation implements SiddhiElement {
             }
         }
         if (annotations != null && annotations.size() > 0) {
-          //  boolean isFirst = true;
+         
             for (Annotation annotation : annotations) {
                 if (!isFirst) {
                     definitionBuilder.append(", ");

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/annotation/Annotation.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/annotation/Annotation.java
@@ -109,9 +109,10 @@ public class Annotation implements SiddhiElement {
 
     @Override
     public String toString() {
+        boolean isFirst = true;
         StringBuilder definitionBuilder = new StringBuilder("@").append(name).append("( ");
         if (elements != null && elements.size() > 0) {
-            boolean isFirst = true;
+          //  boolean isFirst = true;
             for (Element element : elements) {
                 if (!isFirst) {
                     definitionBuilder.append(", ");
@@ -122,7 +123,7 @@ public class Annotation implements SiddhiElement {
             }
         }
         if (annotations != null && annotations.size() > 0) {
-            boolean isFirst = true;
+          //  boolean isFirst = true;
             for (Annotation annotation : annotations) {
                 if (!isFirst) {
                     definitionBuilder.append(", ");


### PR DESCRIPTION
Previously the method misses adding a comma(",")  before the first annotation inside source or sink configuration when trying to retrieve stream definition as a string.
