### PR TITLE
Fix checkstyle issue in TestUtil and renamed TestCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Find the released Siddhi libraries from <a target="_blank" href="http://maven.ws
 
 ## Latest API Docs 
 
-Latest API Docs is <a target="_blank" href="https://wso2.github.io/siddhi/api/4.0.0-M75">4.0.0-M75</a>.
+Latest API Docs is <a target="_blank" href="https://wso2.github.io/siddhi/api/4.0.0-M76-SNAPSHOT">4.0.0-M76-SNAPSHOT</a>.
 
 ## Jenkins Build Status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ Find the released Siddhi libraries from <a target="_blank" href="http://maven.ws
 
 ## Latest API Docs 
 
-Latest API Docs is <a target="_blank" href="https://wso2.github.io/siddhi/api/4.0.0-M75">4.0.0-M75</a>.
+Latest API Docs is <a target="_blank" href="https://wso2.github.io/siddhi/api/4.0.0-M76-SNAPSHOT">4.0.0-M76-SNAPSHOT</a>.
 
 ## Jenkins Build Status
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,5 +29,6 @@ pages:
   - 4.0.0-M73: api/4.0.0-M73.md
   - 4.0.0-M74: api/4.0.0-M74.md
   - 4.0.0-M75: api/4.0.0-M75.md
+  - 4.0.0-M76-SNAPSHOT: api/4.0.0-M76-SNAPSHOT.md
 - License: license.md
 theme: material

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/TestUtil.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/TestUtil.java
@@ -34,34 +34,80 @@ public class TestUtil {
 
     }
 
-    public static TestCallBack addQueryCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
+    /**
+     * Add a callback to the given {@link SiddhiAppRuntime} and validate the assertions.
+     *
+     * @param siddhiAppRuntime the SiddhiAppRuntime
+     * @param queryName        the query
+     * @param expected         expected event data
+     * @return TestCallback
+     */
+    public static TestCallback addQueryCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName,
+                                                Object[]... expected) {
 
-        TestQueryCallBack callBack = new TestQueryCallBack(expected);
+        TestQueryCallback callBack = new TestQueryCallback(expected);
         siddhiAppRuntime.addCallback(queryName, callBack);
         return callBack;
     }
 
-    public static TestCallBack addStreamCallback(SiddhiAppRuntime siddhiAppRuntime, String streamName, Object[]... expected) {
+    /**
+     * Add a callback to the given {@link SiddhiAppRuntime} and validate the assertions.
+     *
+     * @param siddhiAppRuntime the SiddhiAppRuntime
+     * @param streamName       the stream
+     * @param expected         expected event data
+     * @return TestCallback
+     */
+    public static TestCallback addStreamCallback(SiddhiAppRuntime siddhiAppRuntime, String streamName,
+                                                 Object[]... expected) {
 
-        TestStreamCallBack callBack = new TestStreamCallBack(expected);
+        TestStreamCallback callBack = new TestStreamCallback(expected);
         siddhiAppRuntime.addCallback(streamName, callBack);
         return callBack;
     }
 
-    public interface TestCallBack {
+    /**
+     * The API which lets the developers to get the statistics of test results.
+     */
+    public interface TestCallback {
 
+        /**
+         * Returns a list of assertion errors thrown while testing.
+         *
+         * @return a list of assertion errors
+         */
         List<AssertionError> getAssertionErrors();
 
+        /**
+         * Returns the number of events received in.
+         *
+         * @return the number of events received in
+         */
         int getInEventCount();
 
-        int getRemoveEventCount();
+        /**
+         * Returns the number of events removed from. This method can be called only for QueryCallbacks. Otherwise
+         * throws and {@link UnsupportedOperationException}
+         *
+         * @return the number of events removed from
+         * @throws UnsupportedOperationException if the callback was added for a stream
+         */
+        int getRemoveEventCount() throws UnsupportedOperationException;
 
+        /**
+         * Returns true if there is at-least an event received by the query or stream.
+         *
+         * @return true if at-least an event is received otherwise false
+         */
         boolean isEventArrived();
 
+        /**
+         * Throw all the {@link AssertionError}s captured while testing.
+         */
         void throwAssertionErrors();
     }
 
-    private static class TestQueryCallBack extends QueryCallback implements TestCallBack {
+    private static class TestQueryCallback extends QueryCallback implements TestCallback {
 
         private AtomicInteger inEventCount = new AtomicInteger(0);
         private AtomicInteger removeEventCount = new AtomicInteger(0);
@@ -70,7 +116,7 @@ public class TestUtil {
         private final Object[][] expected;
         private final int noOfExpectedEvents;
 
-        public TestQueryCallBack(Object[]... expected) {
+        public TestQueryCallback(Object[]... expected) {
             this.expected = expected;
             this.noOfExpectedEvents = expected.length;
         }
@@ -82,21 +128,14 @@ public class TestUtil {
             EventPrinter.print(timestamp, inEvents, removeEvents);
 
             if (inEvents != null) {
-
-                int inEventsLength = inEvents.length;
-                inEventCount.addAndGet(inEventsLength);
                 eventArrived = true;
-
-                if (noOfExpectedEvents > 0) {
-                    for (int i = 0; i < inEventsLength; i++) {
-
-                        if (i <= noOfExpectedEvents && expected[i] != null) {
-                            try {
-                                Assert.assertArrayEquals(expected[i], inEvents[i].getData());
-                            } catch (AssertionError e) {
-                                // Add the assertion error into the list
-                                assertionErrors.add(e);
-                            }
+                for (Event event : inEvents) {
+                    int inEvent = inEventCount.incrementAndGet();
+                    if (noOfExpectedEvents > 0 && inEvent <= noOfExpectedEvents) {
+                        try {
+                            Assert.assertArrayEquals(expected[inEvent - 1], event.getData());
+                        } catch (AssertionError e) {
+                            assertionErrors.add(e);
                         }
                     }
                 }
@@ -134,7 +173,7 @@ public class TestUtil {
         }
     }
 
-    private static class TestStreamCallBack extends StreamCallback implements TestCallBack {
+    private static class TestStreamCallback extends StreamCallback implements TestCallback {
 
         private AtomicInteger inEventCount = new AtomicInteger(0);
         private boolean eventArrived;
@@ -142,7 +181,7 @@ public class TestUtil {
         private final Object[][] expected;
         private final int noOfExpectedEvents;
 
-        public TestStreamCallBack(Object[]... expected) {
+        public TestStreamCallback(Object[]... expected) {
             this.expected = expected;
             this.noOfExpectedEvents = expected.length;
         }
@@ -153,21 +192,14 @@ public class TestUtil {
             EventPrinter.print(events);
 
             if (events != null) {
-
-                int inEventsLength = events.length;
-                inEventCount.addAndGet(inEventsLength);
                 eventArrived = true;
-
-                if (noOfExpectedEvents > 0) {
-                    for (int i = 0; i < inEventsLength; i++) {
-
-                        if (i <= noOfExpectedEvents && expected[i] != null) {
-                            try {
-                                Assert.assertArrayEquals(expected[i], events[i].getData());
-                            } catch (AssertionError e) {
-                                // Add the assertion error into the list
-                                assertionErrors.add(e);
-                            }
+                for (Event event : events) {
+                    int inEvent = inEventCount.incrementAndGet();
+                    if (noOfExpectedEvents > 0 && inEvent <= noOfExpectedEvents) {
+                        try {
+                            Assert.assertArrayEquals(expected[inEvent - 1], event.getData());
+                        } catch (AssertionError e) {
+                            assertionErrors.add(e);
                         }
                     }
                 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentPatternTestCase.java
@@ -20,19 +20,11 @@ package org.wso2.siddhi.core.query.pattern.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.TestUtil;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.stream.output.StreamCallback;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -42,17 +34,6 @@ import java.util.List;
 public class AbsentPatternTestCase {
 
     private static final Logger log = Logger.getLogger(AbsentPatternTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-    }
 
     @Test
     public void testQueryAbsent1() throws InterruptedException {
@@ -71,7 +52,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        TestUtil.TestCallBack callBack = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -80,10 +61,10 @@ public class AbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 55.6f, 100});
         Thread.sleep(1100);
 
-        callBack.throwAssertionErrors();
-        Assert.assertEquals("Number of success events", 1, callBack.getInEventCount());
-        Assert.assertEquals("Number of remove events", 0, callBack.getRemoveEventCount());
-        Assert.assertTrue("Event not arrived", callBack.isEventArrived());
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -105,7 +86,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -117,12 +98,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -144,7 +123,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -156,12 +135,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(1000);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -183,7 +160,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -195,12 +172,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 50.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -222,7 +197,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -232,9 +207,9 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -256,7 +231,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -269,12 +244,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -296,7 +269,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -308,12 +281,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -335,7 +306,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -347,12 +318,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -375,7 +344,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -390,12 +359,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -418,7 +385,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -433,12 +401,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 25.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -461,7 +427,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -473,12 +440,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 28.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -502,7 +467,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -514,12 +480,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -542,7 +506,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -557,12 +522,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -585,7 +548,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -600,12 +563,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -628,7 +589,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -643,12 +604,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -671,7 +630,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -684,12 +644,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -713,7 +671,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -729,12 +688,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -757,7 +714,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -772,12 +730,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -802,7 +758,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -817,12 +774,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -847,7 +802,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -865,12 +820,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -895,7 +848,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "ORACLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -910,12 +864,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -940,7 +892,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -958,12 +910,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -988,7 +938,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1006,12 +956,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1036,7 +984,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "ORACLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -1049,12 +998,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1079,7 +1026,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1097,12 +1044,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1127,7 +1072,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1142,12 +1087,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1169,7 +1112,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1178,12 +1121,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1208,7 +1149,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1224,12 +1166,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1254,7 +1194,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1270,12 +1210,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1300,7 +1238,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "WSO2", null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1312,12 +1251,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"WSO2", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1342,7 +1279,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", null, "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                null, "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -1355,12 +1293,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1385,7 +1321,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1401,12 +1337,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1431,7 +1365,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1450,12 +1384,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1480,7 +1412,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1499,12 +1431,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1527,7 +1457,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1542,12 +1472,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1570,7 +1498,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", null, null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", null, null});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1583,12 +1512,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1610,7 +1537,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1623,12 +1550,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1651,7 +1576,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1666,12 +1591,10 @@ public class AbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1696,7 +1619,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1712,12 +1635,10 @@ public class AbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1739,7 +1660,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1753,12 +1674,10 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"WSO2", 68.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1779,7 +1698,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -1788,12 +1707,10 @@ public class AbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 55.6f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1815,7 +1732,7 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1825,9 +1742,9 @@ public class AbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1850,22 +1767,8 @@ public class AbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
-            @Override
-            public void receive(Event[] events) {
-                EventPrinter.print(events);
-                eventArrived = true;
-
-                for (Event event : events) {
-                    inEventCount++;
-                    try {
-                        Assert.assertArrayEquals(new Object[]{"customerA"}, event.getData());
-                    } catch (AssertionError e) {
-                        assertionErrors.add(e);
-                    }
-                }
-            }
-        });
+        TestUtil.TestCallback callback = TestUtil.addStreamCallback(siddhiAppRuntime, "OutputStream", new
+                Object[]{"customerA"});
 
         InputHandler customerStream = siddhiAppRuntime.getInputHandler("CustomerStream");
 
@@ -1879,40 +1782,8 @@ public class AbsentPatternTestCase {
 
         siddhiAppRuntime.shutdown();
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentWithEveryPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/AbsentWithEveryPatternTestCase.java
@@ -20,17 +20,11 @@ package org.wso2.siddhi.core.query.pattern.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -40,17 +34,6 @@ import java.util.List;
 public class AbsentWithEveryPatternTestCase {
 
     private static final Logger log = Logger.getLogger(AbsentWithEveryPatternTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-    }
 
     @Test
     public void testQuery1() throws InterruptedException {
@@ -69,7 +52,8 @@ public class AbsentWithEveryPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"GOOG"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"GOOG"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -80,12 +64,10 @@ public class AbsentWithEveryPatternTestCase {
         stream1.send(new Object[]{"GOOG", 55.6f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -107,7 +89,7 @@ public class AbsentWithEveryPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -121,12 +103,10 @@ public class AbsentWithEveryPatternTestCase {
         stream2.send(new Object[]{"IBM", 55.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -151,7 +131,8 @@ public class AbsentWithEveryPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"}, new Object[]{"GOOG", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"}, new Object[]{"GOOG", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -165,12 +146,10 @@ public class AbsentWithEveryPatternTestCase {
         stream3.send(new Object[]{"IBM", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -192,7 +171,8 @@ public class AbsentWithEveryPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"GOOG"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"GOOG"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -204,12 +184,10 @@ public class AbsentWithEveryPatternTestCase {
         stream2.send(new Object[]{"GOOG", 55.6f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -231,7 +209,7 @@ public class AbsentWithEveryPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -245,12 +223,10 @@ public class AbsentWithEveryPatternTestCase {
         stream2.send(new Object[]{"GOOG", 55.6f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -274,7 +250,8 @@ public class AbsentWithEveryPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOG"}, new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOG"}, new Object[]{"WSO2", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -288,42 +265,11 @@ public class AbsentWithEveryPatternTestCase {
         stream3.send(new Object[]{"IBM", 55.8f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/EveryAbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/EveryAbsentPatternTestCase.java
@@ -20,17 +20,11 @@ package org.wso2.siddhi.core.query.pattern.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -44,17 +38,6 @@ import java.util.List;
 public class EveryAbsentPatternTestCase {
 
     private static final Logger log = Logger.getLogger(EveryAbsentPatternTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-    }
 
     @Test
     public void testQueryAbsent1() throws InterruptedException {
@@ -73,7 +56,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"}, new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -82,12 +66,10 @@ public class EveryAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 55.6f, 100});
         Thread.sleep(3200);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 3, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 3, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -109,7 +91,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -118,12 +101,10 @@ public class EveryAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 55.6f, 100});
         Thread.sleep(3200);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -147,7 +128,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler timerStream = siddhiAppRuntime.getInputHandler("TimerStream");
@@ -159,23 +141,21 @@ public class EveryAbsentPatternTestCase {
         timestamp += 1000;
         timerStream.send(timestamp, new Object[]{"UPDATE-TIME"});
         Thread.sleep(100);
-        Assert.assertEquals("Number of success events after first timeout", 1, inEventCount);
+        Assert.assertEquals("Number of success events after first timeout", 1, callback.getInEventCount());
 
         timestamp += 1000;
         timerStream.send(timestamp, new Object[]{"UPDATE-TIME"});
         Thread.sleep(100);
-        Assert.assertEquals("Number of success events after second timeout", 2, inEventCount);
+        Assert.assertEquals("Number of success events after second timeout", 2, callback.getInEventCount());
 
         timestamp += 1000;
         timerStream.send(timestamp, new Object[]{"UPDATE-TIME"});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -197,7 +177,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -209,12 +190,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -236,7 +215,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"},
+                new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -246,12 +226,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -273,7 +251,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -285,12 +263,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -312,7 +288,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -324,12 +301,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 50.7f, 100});
         Thread.sleep(2100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -351,7 +326,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"},
+                new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -361,12 +337,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -388,7 +362,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"},
+                new Object[]{"IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -400,12 +375,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -427,7 +400,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -443,12 +416,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -470,7 +441,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -482,12 +453,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -510,7 +479,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -525,12 +495,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -554,7 +522,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -569,12 +538,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 25.7f, 100});
         Thread.sleep(500);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -597,7 +564,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"}, new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"}, new Object[]{"WSO2", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -609,12 +577,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 28.7f, 100});
         Thread.sleep(2100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -638,7 +604,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -650,12 +617,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -678,7 +643,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -693,12 +659,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -721,7 +685,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -736,12 +700,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -764,7 +726,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -779,12 +741,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -807,7 +767,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"}, new Object[]{"IBM", "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -820,12 +781,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -849,7 +808,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -865,12 +825,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -893,7 +851,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"}, new Object[]{"IBM", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -908,12 +867,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -938,7 +895,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "GOOGLE"}, new Object[]{"WSO2",
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "GOOGLE"}, new Object[]{"WSO2",
                 "IBM", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
@@ -954,12 +912,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
         Thread.sleep(2100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -984,7 +940,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1002,12 +958,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1032,7 +986,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"}, new Object[]{"WSO2",
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "ORACLE"}, new Object[]{"WSO2",
                 "IBM", "ORACLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
@@ -1048,12 +1003,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1078,7 +1031,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "ORACLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1096,12 +1050,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1126,7 +1078,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1144,12 +1096,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1174,7 +1124,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "ORACLE"}, new Object[]{"IBM", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "ORACLE"}, new Object[]{"IBM", "ORACLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -1187,12 +1138,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1217,7 +1166,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1235,12 +1184,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1265,7 +1212,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1280,12 +1227,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1307,7 +1252,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1316,12 +1261,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1344,7 +1287,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1359,12 +1302,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1387,7 +1328,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", null, null}, new Object[]{"WSO2",
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", null, null}, new Object[]{"WSO2",
                 "IBM", null, null});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1401,12 +1343,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1428,7 +1368,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1441,12 +1382,10 @@ public class EveryAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1471,7 +1410,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", "GOOGLE"}, new Object[]{"IBM",
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "WSO2", "GOOGLE"}, new Object[]{"IBM",
                 "WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
@@ -1488,12 +1428,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1518,7 +1456,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1534,12 +1472,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1564,7 +1500,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", null}, new Object[]{"IBM", "WSO2",
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "WSO2", null}, new Object[]{"IBM", "WSO2",
                 null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
@@ -1577,12 +1514,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"WSO2", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1607,7 +1542,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", null, "GOOGLE"}, new Object[]{"IBM", null,
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                null, "GOOGLE"}, new Object[]{"IBM", null,
                 "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
@@ -1622,12 +1558,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1652,7 +1586,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1668,12 +1602,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1698,7 +1630,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1717,12 +1649,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1747,7 +1677,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1766,12 +1696,10 @@ public class EveryAbsentPatternTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1794,7 +1722,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"}, new Object[]{"WSO2", "ORACLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1809,12 +1738,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1837,7 +1764,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1853,12 +1780,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1881,7 +1806,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1896,12 +1822,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1924,7 +1848,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1940,12 +1864,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1968,7 +1890,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"}, new Object[]{"WSO2", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"}, new Object[]{"WSO2", "ORACLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1982,12 +1905,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2010,7 +1931,7 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2025,12 +1946,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2053,7 +1972,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2068,12 +1988,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2096,7 +2014,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2111,12 +2030,10 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2139,7 +2056,8 @@ public class EveryAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2157,42 +2075,11 @@ public class EveryAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
@@ -20,18 +20,11 @@ package org.wso2.siddhi.core.query.pattern.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.stream.output.StreamCallback;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -47,18 +40,6 @@ import java.util.List;
 public class LogicalAbsentPatternTestCase {
 
     private static final Logger log = Logger.getLogger(LogicalAbsentPatternTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-        assertionErrors.clear();
-    }
 
     @Test
     public void testQueryAbsent1() throws InterruptedException {
@@ -77,7 +58,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -88,12 +70,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -115,7 +95,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -129,12 +109,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -156,7 +134,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -167,12 +146,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -194,7 +171,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -208,12 +185,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -235,7 +210,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -246,12 +222,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -273,7 +247,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -284,12 +259,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(600);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -311,7 +284,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -323,12 +296,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -350,7 +321,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -361,12 +332,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -388,7 +357,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -402,12 +371,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -429,7 +396,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -441,12 +409,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -468,7 +434,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -479,12 +446,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -506,7 +471,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -521,12 +486,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -548,7 +511,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -559,12 +522,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -586,7 +547,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -600,12 +562,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -627,7 +587,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -638,12 +599,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -666,7 +625,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -677,12 +637,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -704,7 +662,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         siddhiAppRuntime.start();
@@ -712,12 +671,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -739,7 +696,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         siddhiAppRuntime.start();
@@ -747,12 +704,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -775,7 +730,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -789,12 +745,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -817,7 +771,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -828,12 +782,10 @@ public class LogicalAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -855,7 +807,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -866,12 +819,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -893,7 +844,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "GOOGLE"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -902,12 +854,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -929,7 +879,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -937,12 +887,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -964,7 +912,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -975,12 +924,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1003,7 +950,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1014,12 +961,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1041,7 +986,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1055,12 +1000,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1083,7 +1026,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1094,12 +1038,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1122,7 +1064,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1133,12 +1075,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1161,7 +1101,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         siddhiAppRuntime.start();
@@ -1169,12 +1109,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1197,7 +1135,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1208,12 +1146,10 @@ public class LogicalAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 101});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1236,7 +1172,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1247,12 +1183,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"IBM", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1275,7 +1209,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1289,12 +1223,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"ORACLE", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1317,7 +1249,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         siddhiAppRuntime.start();
@@ -1325,12 +1257,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1353,7 +1283,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1364,12 +1294,10 @@ public class LogicalAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 101});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1392,7 +1320,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1403,12 +1331,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"IBM", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1433,7 +1359,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1447,12 +1373,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"ORACLE", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1475,7 +1399,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -1487,12 +1411,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1514,7 +1436,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1527,12 +1449,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1554,7 +1474,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1567,12 +1487,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1594,7 +1512,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1609,12 +1527,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1637,7 +1553,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -1647,12 +1563,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1674,7 +1588,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1687,12 +1601,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1714,7 +1626,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1727,12 +1639,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1754,7 +1664,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1769,12 +1679,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1796,7 +1704,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1807,12 +1716,10 @@ public class LogicalAbsentPatternTestCase {
         stream2.send(new Object[]{"GOOGLE", 25.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1834,7 +1741,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1843,12 +1751,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1870,7 +1776,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1881,12 +1788,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1908,7 +1813,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "GOOGLE"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -1917,12 +1823,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1944,7 +1848,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -1953,12 +1857,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1981,7 +1883,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1999,12 +1902,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2027,8 +1928,9 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"}, new Object[]{"IBM"}, new
-                Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"}, new Object[]{"IBM"}, new
+                        Object[]{"IBM"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2040,12 +1942,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 4, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 4, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2068,8 +1968,9 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"}, new Object[]{"WSO2"}, new
-                Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"}, new Object[]{"WSO2"}, new
+                        Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2079,12 +1980,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 4, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 4, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2107,7 +2006,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"IBM"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2119,12 +2019,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2147,7 +2045,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2157,12 +2056,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2185,7 +2082,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"ORACLE", "MICROSOFT"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"}, new Object[]{"ORACLE", "MICROSOFT"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2202,12 +2100,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"MICROSOFT", 55.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2230,7 +2126,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2248,12 +2145,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2276,7 +2171,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                        "WSO2"}, new Object[]{null, "IBM"},
                 new Object[]{"ORACLE", "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2294,12 +2190,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 3, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 3, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2322,7 +2216,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "WSO2"}, new Object[]{null, "WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2332,12 +2227,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2360,7 +2253,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2379,12 +2273,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2407,7 +2299,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2424,12 +2317,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2452,7 +2343,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2462,12 +2353,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2490,7 +2379,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2508,12 +2398,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2536,7 +2424,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                        "WSO2"}, new Object[]{null, "IBM"},
                 new Object[]{"ORACLE", "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2554,12 +2443,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 3, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 3, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2582,7 +2469,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "WSO2"}, new Object[]{null, "WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2592,12 +2480,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2620,7 +2506,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "GOOGLE"}, new Object[]{"WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2639,12 +2526,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2667,7 +2552,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2684,12 +2570,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2712,7 +2596,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -2722,12 +2606,10 @@ public class LogicalAbsentPatternTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2751,7 +2633,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOGLE", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"GOOGLE",
+                "ORACLE"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -2763,9 +2646,9 @@ public class LogicalAbsentPatternTestCase {
         stream4.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2787,7 +2670,8 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2798,12 +2682,10 @@ public class LogicalAbsentPatternTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2824,7 +2706,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         siddhiAppRuntime.start();
@@ -2832,12 +2714,10 @@ public class LogicalAbsentPatternTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2857,7 +2737,7 @@ public class LogicalAbsentPatternTestCase {
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         siddhiAppRuntime.start();
@@ -2867,12 +2747,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"IBM", 20.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2896,22 +2774,8 @@ public class LogicalAbsentPatternTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
-            @Override
-            public void receive(Event[] events) {
-                EventPrinter.print(events);
-                eventArrived = true;
-
-                for (Event event : events) {
-                    inEventCount++;
-                    try {
-                        Assert.assertArrayEquals(new Object[]{"WSO2"}, event.getData());
-                    } catch (AssertionError e) {
-                        assertionErrors.add(e);
-                    }
-                }
-            }
-        });
+        TestUtil.TestCallback callback = TestUtil.addStreamCallback(siddhiAppRuntime, "OutputStream",
+                new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         siddhiAppRuntime.start();
@@ -2922,42 +2786,10 @@ public class LogicalAbsentPatternTestCase {
         stream1.send(new Object[]{"IBM", 20.0f, 15});
         Thread.sleep(600);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentSequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentSequenceTestCase.java
@@ -20,17 +20,11 @@ package org.wso2.siddhi.core.query.sequence.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -40,17 +34,6 @@ import java.util.List;
 public class AbsentSequenceTestCase {
 
     private static final Logger log = Logger.getLogger(AbsentSequenceTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-    }
 
     @Test
     public void testQueryAbsent1() throws InterruptedException {
@@ -69,7 +52,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -78,12 +61,10 @@ public class AbsentSequenceTestCase {
         stream1.send(new Object[]{"WSO2", 55.6f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -105,7 +86,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -117,12 +98,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -144,7 +123,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -156,12 +135,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(1000);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -183,7 +160,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -195,12 +172,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 50.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -222,7 +197,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -232,12 +207,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -259,7 +232,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -272,12 +245,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -299,7 +270,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -311,12 +282,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -338,7 +307,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -350,12 +319,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -378,7 +345,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -393,12 +360,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -421,7 +386,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -436,12 +402,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 25.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -464,7 +428,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -476,12 +441,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 28.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -505,7 +468,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -517,12 +481,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -545,7 +507,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -560,12 +523,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -588,7 +549,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -603,12 +564,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -631,7 +590,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -646,12 +605,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -674,7 +631,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -687,12 +645,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -716,7 +672,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -732,12 +689,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -760,7 +715,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -775,12 +730,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -805,7 +758,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -820,12 +774,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -850,7 +802,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -868,12 +820,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -898,7 +848,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "IBM", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "IBM", "ORACLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -913,12 +864,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -943,7 +892,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -961,12 +910,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -991,7 +938,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1009,12 +956,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1039,7 +984,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "ORACLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -1052,12 +998,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1082,7 +1026,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1100,12 +1044,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1130,7 +1072,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1145,12 +1087,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1172,7 +1112,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1181,12 +1121,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1211,7 +1149,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "WSO2", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1227,12 +1166,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1257,7 +1194,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1273,12 +1210,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1303,7 +1238,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "WSO2", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "WSO2", null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1315,12 +1251,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"WSO2", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1345,7 +1279,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", null, "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                null, "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -1358,12 +1293,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1388,7 +1321,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1404,12 +1337,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1434,7 +1365,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1453,12 +1384,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1483,7 +1412,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1502,12 +1431,10 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1530,7 +1457,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1545,12 +1472,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1573,7 +1498,8 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "WSO2", "IBM", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE",
+                "WSO2", "IBM", null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1588,12 +1514,10 @@ public class AbsentSequenceTestCase {
         stream1.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1615,7 +1539,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -1628,12 +1552,10 @@ public class AbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1656,7 +1578,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1671,12 +1593,10 @@ public class AbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1701,7 +1621,7 @@ public class AbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1717,42 +1637,11 @@ public class AbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentWithEverySequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/AbsentWithEverySequenceTestCase.java
@@ -20,17 +20,11 @@ package org.wso2.siddhi.core.query.sequence.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -39,17 +33,6 @@ import java.util.List;
 public class AbsentWithEverySequenceTestCase {
 
     private static final Logger log = Logger.getLogger(AbsentWithEverySequenceTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-    }
 
     @Test
     public void testQuery1() throws InterruptedException {
@@ -68,7 +51,7 @@ public class AbsentWithEverySequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOG"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"GOOG"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -79,12 +62,10 @@ public class AbsentWithEverySequenceTestCase {
         stream1.send(new Object[]{"GOOG", 55.6f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -106,7 +87,7 @@ public class AbsentWithEverySequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -120,12 +101,10 @@ public class AbsentWithEverySequenceTestCase {
         stream2.send(new Object[]{"IBM", 55.7f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -150,7 +129,8 @@ public class AbsentWithEverySequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOG", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"GOOG",
+                "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -164,43 +144,11 @@ public class AbsentWithEverySequenceTestCase {
         stream3.send(new Object[]{"IBM", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/EveryAbsentSequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/EveryAbsentSequenceTestCase.java
@@ -20,17 +20,11 @@ package org.wso2.siddhi.core.query.sequence.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -44,17 +38,6 @@ import java.util.List;
 public class EveryAbsentSequenceTestCase {
 
     private static final Logger log = Logger.getLogger(EveryAbsentSequenceTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-    }
 
     @Test
     public void testQueryAbsent1() throws InterruptedException {
@@ -73,7 +56,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -83,12 +66,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -111,7 +92,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"}, new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"},
+                new Object[]{"WSO2"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -123,12 +105,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"WSO2", 68.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -150,7 +130,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -162,12 +142,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -189,7 +167,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -205,12 +183,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -232,7 +208,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -244,12 +220,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -273,7 +247,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -288,12 +262,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -316,7 +288,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -331,12 +303,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -359,7 +329,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -372,12 +343,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -401,7 +370,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -417,12 +387,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -445,7 +413,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -460,12 +429,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -488,7 +455,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -503,12 +470,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 55.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -533,7 +498,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -551,12 +516,10 @@ public class EveryAbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 44.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -578,7 +541,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -587,12 +550,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 58.7f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -615,7 +576,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -630,12 +591,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -658,7 +617,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -673,12 +633,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -700,7 +658,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"IBM"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
@@ -713,12 +672,10 @@ public class EveryAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 45.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -743,7 +700,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -759,12 +716,10 @@ public class EveryAbsentSequenceTestCase {
         stream4.send(new Object[]{"GOOGLE", 56.86f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event not arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event not arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -788,7 +743,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -803,12 +759,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -831,7 +785,7 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -847,12 +801,10 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -875,7 +827,8 @@ public class EveryAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -893,42 +846,11 @@ public class EveryAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/LogicalAbsentSequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/sequence/absent/LogicalAbsentSequenceTestCase.java
@@ -20,17 +20,11 @@ package org.wso2.siddhi.core.query.sequence.absent;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.TestUtil;
 import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.util.EventPrinter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Test the patterns:
@@ -46,18 +40,6 @@ import java.util.List;
 public class LogicalAbsentSequenceTestCase {
 
     private static final Logger log = Logger.getLogger(LogicalAbsentSequenceTestCase.class);
-    private int inEventCount;
-    private int removeEventCount;
-    private boolean eventArrived;
-    private List<AssertionError> assertionErrors = new ArrayList<>();
-
-    @Before
-    public void init() {
-        inEventCount = 0;
-        removeEventCount = 0;
-        eventArrived = false;
-        assertionErrors.clear();
-    }
 
     @Test
     public void testQueryAbsent1() throws InterruptedException {
@@ -77,7 +59,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -90,12 +73,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -118,7 +99,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -134,12 +115,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -162,7 +141,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -175,12 +155,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -203,7 +181,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -219,12 +197,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -247,7 +223,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -259,12 +236,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -287,7 +262,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -300,12 +275,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -328,7 +301,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -344,12 +317,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -372,7 +343,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -386,12 +358,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -414,7 +384,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -427,12 +397,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -455,7 +423,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -471,12 +440,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -499,7 +466,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -511,12 +479,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -540,7 +506,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -552,12 +519,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -580,7 +545,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -590,12 +556,10 @@ public class LogicalAbsentSequenceTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -618,7 +582,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -628,12 +592,10 @@ public class LogicalAbsentSequenceTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -657,7 +619,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -673,12 +636,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -701,7 +662,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -714,12 +675,10 @@ public class LogicalAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -742,7 +701,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -754,12 +714,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -782,7 +740,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "GOOGLE"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -792,12 +751,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -820,7 +777,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -829,12 +786,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -857,7 +812,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -870,12 +826,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -899,7 +853,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -912,12 +866,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -940,7 +892,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -956,12 +908,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -985,7 +935,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -997,12 +948,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1026,7 +975,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1038,12 +987,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1067,7 +1014,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -1076,12 +1023,10 @@ public class LogicalAbsentSequenceTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1105,7 +1050,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1117,12 +1062,10 @@ public class LogicalAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 101});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1146,7 +1089,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1158,12 +1101,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"IBM", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1187,7 +1128,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1202,12 +1143,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"ORACLE", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1231,7 +1170,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
 
@@ -1240,12 +1179,10 @@ public class LogicalAbsentSequenceTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1269,7 +1206,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1281,12 +1218,10 @@ public class LogicalAbsentSequenceTestCase {
         stream2.send(new Object[]{"IBM", 25.0f, 101});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1310,7 +1245,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1322,12 +1257,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"IBM", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1352,7 +1285,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1367,12 +1300,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"ORACLE", 35.0f, 102});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1396,7 +1327,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -1409,12 +1340,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1437,7 +1366,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1451,12 +1380,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1479,7 +1406,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1493,12 +1420,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1521,7 +1446,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1537,12 +1462,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1566,7 +1489,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -1577,12 +1500,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1605,7 +1526,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1619,12 +1540,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1647,7 +1566,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1661,12 +1580,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1689,7 +1606,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1705,12 +1622,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1733,7 +1648,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1745,12 +1661,10 @@ public class LogicalAbsentSequenceTestCase {
         stream2.send(new Object[]{"GOOGLE", 25.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1773,7 +1687,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", null});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                null});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1783,12 +1698,10 @@ public class LogicalAbsentSequenceTestCase {
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
         Thread.sleep(1100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1811,7 +1724,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -1823,12 +1737,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1851,7 +1763,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "GOOGLE"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -1860,12 +1773,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1888,7 +1799,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         siddhiAppRuntime.start();
@@ -1897,12 +1808,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1926,7 +1835,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -1945,12 +1855,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -1974,7 +1882,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"IBM"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -1987,12 +1896,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2016,7 +1923,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2027,12 +1934,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2056,7 +1961,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"}, new Object[]{"IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"},
+                new Object[]{"IBM"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2069,12 +1975,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2098,7 +2002,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2109,12 +2013,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2138,7 +2040,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"}, new Object[]{"ORACLE", "MICROSOFT"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"}, new Object[]{"ORACLE", "MICROSOFT"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2157,12 +2060,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"MICROSOFT", 55.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 2, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 2, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2186,7 +2087,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2205,12 +2107,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2234,7 +2134,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                        "WSO2"}, new Object[]{null, "IBM"},
                 new Object[]{"ORACLE", "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2253,12 +2154,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 3, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 3, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2282,7 +2181,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2293,12 +2193,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2322,7 +2220,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2342,12 +2241,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2371,7 +2268,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2389,12 +2287,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2418,7 +2314,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2429,12 +2325,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2458,7 +2352,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"MICROSOFT", "IBM"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new
+                Object[]{"MICROSOFT", "IBM"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2477,12 +2372,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2506,7 +2399,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"}, new Object[]{null, "IBM"},
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                        "WSO2"}, new Object[]{null, "IBM"},
                 new Object[]{"ORACLE", "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2525,12 +2419,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 3, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 3, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2554,7 +2446,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{null, "WSO2"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{null,
+                "WSO2"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2565,12 +2458,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2594,7 +2485,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2614,12 +2506,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2643,7 +2533,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"ORACLE",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2661,12 +2552,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2690,7 +2579,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
 
@@ -2701,12 +2590,10 @@ public class LogicalAbsentSequenceTestCase {
         Thread.sleep(100);
 
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2731,7 +2618,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"GOOGLE", "ORACLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"GOOGLE",
+                "ORACLE"});
 
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
         InputHandler stream4 = siddhiAppRuntime.getInputHandler("Stream4");
@@ -2745,9 +2633,9 @@ public class LogicalAbsentSequenceTestCase {
         stream4.send(new Object[]{"ORACLE", 45.0f, 100});
         Thread.sleep(100);
 
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2770,7 +2658,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"WSO2",
+                "GOOGLE"});
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2782,12 +2671,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(600);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2810,7 +2697,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2823,12 +2710,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2851,7 +2736,8 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1", new Object[]{"IBM", "GOOGLE"});
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1", new Object[]{"IBM",
+                "GOOGLE"});
 
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
         InputHandler stream3 = siddhiAppRuntime.getInputHandler("Stream3");
@@ -2864,12 +2750,10 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 1, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertTrue("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 1, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertTrue("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
     }
@@ -2892,7 +2776,7 @@ public class LogicalAbsentSequenceTestCase {
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
 
-        addCallback(siddhiAppRuntime, "query1");
+        TestUtil.TestCallback callback = TestUtil.addQueryCallback(siddhiAppRuntime, "query1");
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
         InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
@@ -2909,42 +2793,11 @@ public class LogicalAbsentSequenceTestCase {
         stream3.send(new Object[]{"GOOGLE", 35.0f, 100});
         Thread.sleep(100);
 
-        for (AssertionError e : this.assertionErrors) {
-            throw e;
-        }
-        Assert.assertEquals("Number of success events", 0, inEventCount);
-        Assert.assertEquals("Number of remove events", 0, removeEventCount);
-        Assert.assertFalse("Event arrived", eventArrived);
+        callback.throwAssertionErrors();
+        Assert.assertEquals("Number of success events", 0, callback.getInEventCount());
+        Assert.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
+        Assert.assertFalse("Event arrived", callback.isEventArrived());
 
         siddhiAppRuntime.shutdown();
-    }
-
-    private void addCallback(SiddhiAppRuntime siddhiAppRuntime, String queryName, Object[]... expected) {
-        final int noOfExpectedEvents = expected.length;
-        siddhiAppRuntime.addCallback(queryName, new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-                if (inEvents != null) {
-                    eventArrived = true;
-
-                    for (Event event : inEvents) {
-                        inEventCount++;
-                        if (noOfExpectedEvents > 0 && inEventCount <= noOfExpectedEvents) {
-                            try {
-                                Assert.assertArrayEquals(expected[inEventCount - 1], event.getData());
-                            } catch (AssertionError e) {
-                                assertionErrors.add(e);
-                            }
-                        }
-                    }
-                }
-                if (removeEvents != null) {
-                    removeEventCount = removeEventCount + removeEvents.length;
-                }
-                eventArrived = true;
-            }
-
-        });
     }
 }


### PR DESCRIPTION
This PR contains the fix for the check-style issue caused by my last PR #510.
I have also changed the `TestCallback` interface name according to your feedback and used this class in all absent pattern & sequence test classes.