### PR TITLE
3.1.x

### DIFF
--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/DBConnectionHelper.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/DBConnectionHelper.java
@@ -109,7 +109,7 @@ public class DBConnectionHelper {
             con.commit();
             return stmt.execute();
         } catch (SQLException e) {
-            log.error("Error while creating the event", e);
+            log.info("Table '" + tableName + "' is not existed.", e);
             return false;
         } finally {
             clearConnections(stmt, con);

--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/DeleteFromRDBMSTestCase.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/DeleteFromRDBMSTestCase.java
@@ -638,6 +638,8 @@ public class DeleteFromRDBMSTestCase {
                 Thread.sleep(1000);
                 executionPlanRuntime.shutdown();
 
+            } else {
+                throw new ExecutionPlanRuntimeException("Execution plan execution failed.");
             }
         } catch (SQLException e) {
             log.info("Test case ignored due to DB connection unavailability");

--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/InsertIntoRDBMSTestCase.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/InsertIntoRDBMSTestCase.java
@@ -110,6 +110,8 @@ public class InsertIntoRDBMSTestCase {
                 Thread.sleep(1000);
 
                 executionPlanRuntime.shutdown();
+            } else {
+                throw new ExecutionPlanRuntimeException("Execution plan execution failed.");
             }
         } catch (SQLException e) {
             log.info("Test case ignored due to DB connection unavailability");

--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/InsertOverwriteTableTestCase.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/InsertOverwriteTableTestCase.java
@@ -377,6 +377,8 @@ public class InsertOverwriteTableTestCase {
                 Assert.assertEquals("Event arrived", false, eventArrived);
 
                 executionPlanRuntime.shutdown();
+            } else {
+                throw new DuplicateDefinitionException("Execution failed due to duplicate definitions.");
             }
         } catch (SQLException e) {
             log.info("Test case ignored due to DB connection unavailability");

--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/JoinRDBMSTableTestCase.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/JoinRDBMSTableTestCase.java
@@ -689,7 +689,113 @@ public class JoinRDBMSTableTestCase {
                         "define stream StockStream (symbol string, price float, volume long); " +
                         "define stream CheckStockStream (symbol string); " +
                         "@from(eventtable = 'rdbms' , jdbc.url = 'jdbc:mysql://localhost:3306/cepdb' , username = 'root' , password = 'root' , driver.name = 'com.mysql.jdbc.Driver' , table.name = '" + RDBMSTestConstants.TABLE_NAME + "') " +
-                        "@connection(maxWait = '4000')" +
+                        "@connection(" +
+                        "maxWait = '4000'," +
+                        "maxIdle = '5000', minIdle = '1000'," +
+                        "maxActive = '6000'," +
+                        "initialSize = '5'," +
+                        "testOnBorrow = 'true'," +
+                        "validationQuery = 'SELECT 1 FROM " + RDBMSTestConstants.TABLE_NAME + " LIMIT 1;'," +
+                        "validationInterval = '2000'," +
+                        "testOnReturn = 'false'," +
+                        "testWhileIdle = 'true'," +
+                        "timeBetweenEvictionRunsMillis = '1000'," +
+                        "numTestsPerEvictionRun = '2'," +
+                        "minEvictableIdleTimeMillis = '1000'," +
+                        "accessToUnderlyingConnectionAllowed = 'true'," +
+                        "removeAbandoned = 'true'," +
+                        "removeAbandonedTimeout = '2'," +
+                        "logAbandoned = 'true'," +
+                        "initSQL = 'SELECT 1 FROM " + RDBMSTestConstants.TABLE_NAME + " LIMIT 1;'," +
+                        "jdbcInterceptors = 'org.apache.tomcat.jdbc.pool.interceptor.ConnectionState', " +
+                        "jmxEnabled = 'true'," +
+                        "fairQueue = 'true'," +
+                        "abandonWhenPercentageFull = '50'," +
+                        "maxAge = '10000'," +
+                        "useEquals = 'true'," +
+                        "suspectTimeout = '6000'," +
+                        "validationQueryTimeout = '6000'," +
+                        "alternateUsernameAllowed = 'true' )" +
+                        "define table StockTable (symbol string, price float, volume long); ";
+                String query = "" +
+                        "@info(name = 'query1') " +
+                        "from StockStream " +
+                        "insert into StockTable ;" +
+                        "" +
+                        "@info(name = 'query2') " +
+                        "from CheckStockStream#window.length(1) join StockTable " +
+                        "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, StockTable.volume as volume  " +
+                        "insert into OutputStream ;";
+
+                ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(streams + query);
+
+                executionPlanRuntime.addCallback("query2", new QueryCallback() {
+                    @Override
+                    public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                        EventPrinter.print(timeStamp, inEvents, removeEvents);
+                        if (inEvents != null) {
+                            for (Event event : inEvents) {
+                                inEventCount++;
+                                switch (inEventCount) {
+                                    case 1:
+                                        Assert.assertArrayEquals(new Object[]{"WSO2", "WSO2", 100l}, event.getData());
+                                        break;
+                                    case 2:
+                                        Assert.assertArrayEquals(new Object[]{"WSO2", "IBM", 10l}, event.getData());
+                                        break;
+                                    default:
+                                        Assert.assertSame(2, inEventCount);
+                                }
+                            }
+                            eventArrived = true;
+                        }
+                        if (removeEvents != null) {
+                            removeEventCount = removeEventCount + removeEvents.length;
+                        }
+                        eventArrived = true;
+                    }
+
+                });
+
+                InputHandler stockStream = executionPlanRuntime.getInputHandler("StockStream");
+                InputHandler checkStockStream = executionPlanRuntime.getInputHandler("CheckStockStream");
+
+                executionPlanRuntime.start();
+
+                stockStream.send(new Object[]{"WSO2", 55.6f, 100l});
+                stockStream.send(new Object[]{"IBM", 75.6f, 10l});
+                checkStockStream.send(new Object[]{"WSO2"});
+
+                Thread.sleep(1000);
+
+                Assert.assertEquals("Number of success events", 2, inEventCount);
+                Assert.assertEquals("Number of remove events", 0, removeEventCount);
+                Assert.assertEquals("Event arrived", true, eventArrived);
+
+                executionPlanRuntime.shutdown();
+            }
+        } catch (SQLException e) {
+            log.info("Test case ignored due to DB connection unavailability");
+        }
+
+    }
+
+    @Test
+    public void testTableJoinQuery10() throws InterruptedException {
+        log.info("testTableJoinQuery10 - OUT 3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setDataSource(RDBMSTestConstants.DATA_SOURCE_NAME, dataSource);
+
+        try {
+            if ((dataSource.getConnection()) != null) {
+                DBConnectionHelper.getDBConnectionHelperInstance().clearDatabaseTable(dataSource,RDBMSTestConstants.TABLE_NAME);
+
+                String streams = "" +
+                        "define stream StockStream (symbol string, price float, volume long); " +
+                        "define stream CheckStockStream (symbol string); " +
+                        "@from(eventtable = 'rdbms' , jdbc.url = 'jdbc:mysql://localhost:3306/cepdb' , username = 'root' , password = 'root' , driver.name = 'com.mysql.jdbc.Driver' , table.name = '" + RDBMSTestConstants.TABLE_NAME + "') " +
+                        "@connection(maxWait = '4000abc')" +
                         "define table StockTable (symbol string, price float, volume long); ";
                 String query = "" +
                         "@info(name = 'query1') " +

--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/UpdateFromRDBMSTestCase.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/UpdateFromRDBMSTestCase.java
@@ -561,6 +561,8 @@ public class UpdateFromRDBMSTestCase {
                 long totalRowsInTable = DBConnectionHelper.getDBConnectionHelperInstance().getRowsInTable(dataSource);
                 Assert.assertEquals("Update failed", 3, totalRowsInTable);
                 executionPlanRuntime.shutdown();
+            } else {
+                throw new ExecutionPlanRuntimeException("Execution plan execution failed.");
             }
         } catch (SQLException e) {
             log.info("Test case ignored due to DB connection unavailability");

--- a/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/UpdateFromRDBMSTestCase.java
+++ b/modules/siddhi-extensions/event-table/src/test/java/org/wso2/siddhi/extension/eventtable/rdbms/UpdateFromRDBMSTestCase.java
@@ -739,5 +739,62 @@ public class UpdateFromRDBMSTestCase {
         }
     }
 
+    @Test
+    public void updateFromRDBMSTableTest12() throws InterruptedException {
+
+        log.info("updateFromTableTest1");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setDataSource(RDBMSTestConstants.DATA_SOURCE_NAME, dataSource);
+
+        try {
+            if (dataSource.getConnection() != null) {
+
+                DBConnectionHelper.getDBConnectionHelperInstance().clearDatabaseTable(dataSource,
+                        RDBMSTestConstants.TABLE_NAME);
+                String streams = "" +
+                        "define stream StockStream (symbol string, price float, volume long); " +
+                        "define stream UpdateStockStream (symbol string, price float, volume long); " +
+                        "@from(eventtable = 'rdbms' ," +
+                        "datasource.name = '" + RDBMSTestConstants.DATA_SOURCE_NAME + "' , " +
+                        "table.name = '" + RDBMSTestConstants.TABLE_NAME + "', " +
+                        "bloom.filters = 'enable')  " +
+                        "define table StockTable (symbol string, price float, volume long); ";
+
+                String query = "" +
+                        "@info(name = 'query1') " +
+                        "from StockStream " +
+                        "insert into StockTable ;" +
+                        "" +
+                        "@info(name = 'query2') " +
+                        "from UpdateStockStream " +
+                        "update StockTable " +
+                        "   on StockTable.symbol == symbol ;";
+
+                ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(streams + query);
+
+                InputHandler stockStream = executionPlanRuntime.getInputHandler("StockStream");
+                InputHandler updateStockStream = executionPlanRuntime.getInputHandler("UpdateStockStream");
+
+                executionPlanRuntime.start();
+
+                stockStream.send(new Object[]{"WSO2", 55.6f, 100l});
+                stockStream.send(new Object[]{"IBM", 75.6f, 100l});
+                stockStream.send(new Object[]{"WSO2", 57.6f, 100l});
+                updateStockStream.send(new Object[]{"IBM", 57.6f, 100l});
+
+                Thread.sleep(1000);
+                long totalRowsInTable = DBConnectionHelper.getDBConnectionHelperInstance().getRowsInTable(dataSource);
+                Assert.assertEquals("Update failed", 3, totalRowsInTable);
+                executionPlanRuntime.shutdown();
+            }
+        } catch (SQLException e) {
+            log.info("Test case ignored due to DB connection unavailability");
+        }
+
+    }
+
+
+
 
 }


### PR DESCRIPTION
Forcibly throw expected exception if db connection fails in rdbms test cases. 
This will prevent test failures where database does not exist.