### PR TITLE
Siddhi Doc Gen Plugin - Re-implement "change the mkdocs gh-deploy to a manual git push"

### DIFF
--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/ExtensionsIndexGenerationMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/ExtensionsIndexGenerationMojo.java
@@ -40,9 +40,9 @@ import java.util.List;
 )
 public class ExtensionsIndexGenerationMojo extends AbstractMojo {
     /**
-     * The directory in which the documentation will be generated
+     * The maven project object
      */
-    @Parameter(defaultValue = "${project}", readonly = true)
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject mavenProject;
 
     /**

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MarkdownDocumentationGenerationMojo.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/MarkdownDocumentationGenerationMojo.java
@@ -45,9 +45,9 @@ import java.util.List;
 )
 public class MarkdownDocumentationGenerationMojo extends AbstractMojo {
     /**
-     * The maven project object for the current module
+     * The maven project object
      */
-    @Parameter(defaultValue = "${project}", readonly = true)
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject mavenProject;
 
     /**

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/Constants.java
@@ -48,30 +48,42 @@ public class Constants {
 
     public static final String GITHUB_GPL_EXTENSION_REPOSITORY_PREFIX = "siddhi-gpl-";
     public static final String GITHUB_APACHE_EXTENSION_REPOSITORY_PREFIX = "siddhi-";
-    public static final String GITHUB_EXTENSION_REPOSITORY_PARENT_POSTFIX = "-parent";
     public static final String GITHUB_OWNER_WSO2_EXTENSIONS = "wso2-extensions";
+
+    public static final String SYSTEM_PROPERTY_SCM_USERNAME_KEY = "SCM_USERNAME";
+    public static final String SYSTEM_PROPERTY_SCM_PASSWORD_KEY = "SCM_PASSWORD";
 
     public static final String MKDOCS_CONFIG_PAGES_KEY = "pages";
     public static final String MKDOCS_CONFIG_PAGES_API_KEY = "API Docs";
     public static final String MKDOCS_FILE_SEPARATOR = "/";
+    public static final String MKDOCS_SITE_DIRECTORY = "site";
 
     public static final String MKDOCS_COMMAND = "mkdocs";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND = "gh-deploy";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_CONFIG_FILE_ARGUMENT = "-f";
-    public static final String MKDOCS_GITHUB_DEPLOY_COMMAND_MESSAGE_ARGUMENT = "-m";
+    public static final String MKDOCS_BUILD_COMMAND = "build";
+    public static final String MKDOCS_BUILD_COMMAND_CLEAN_ARGUEMENT = "-c";
+    public static final String MKDOCS_BUILD_COMMAND_CONFIG_FILE_ARGUMENT = "-f";
+    public static final String MKDOCS_BUILD_COMMAND_SITE_DIRECTORY_ARGUMENT = "-d";
+
+    public static final String GIT_REMOTE = "origin";
+    public static final String GIT_REMOTE_WITH_USERNAME_PASSWORD = "https://%s:%s@github.com/wso2/siddhi.git";
+    public static final String GIT_MASTER_BRANCH = "master";
+    public static final String GIT_GH_PAGES_BRANCH = "gh-pages";
 
     public static final String GIT_COMMAND = "git";
+    public static final String GIT_BRANCH_COMMAND = "branch";
+    public static final String GIT_BRANCH_COMMAND_OUTPUT_CURRENT_BRANCH_PREFIX = "* ";
+    public static final String GIT_STASH_COMMAND = "stash";
+    public static final String GIT_STASH_POP_COMMAND = "pop";
     public static final String GIT_ADD_COMMAND = "add";
+    public static final String GIT_PULL_COMMAND = "pull";
     public static final String GIT_PUSH_COMMAND = "push";
-    public static final String GIT_PUSH_COMMAND_REMOTE = "origin";
-    public static final String GIT_PUSH_COMMAND_REMOTE_BRANCH = "master";
+    public static final String GIT_CHECKOUT_COMMAND = "checkout";
+    public static final String GIT_CHECKOUT_COMMAND_ORPHAN_ARGUMENT = "--orphan";
     public static final String GIT_COMMIT_COMMAND = "commit";
     public static final String GIT_COMMIT_COMMAND_FILES_ARGUMENT = "--";
     public static final String GIT_COMMIT_COMMAND_MESSAGE_ARGUMENT = "-m";
     public static final String GIT_COMMIT_COMMAND_MESSAGE_FORMAT = "[WSO2-Release] [Release %s] " +
             "update documentation for release %s";
-
-    public static final String URL_PREFIX_BASE = ".";
 
     public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     public static final String CORE_NAMESPACE = "core";
@@ -84,4 +96,5 @@ public class Constants {
     public static final String FREEMARKER_LATEST_API_DOCS_HEADING = "## Latest API Docs";
     public static final String FREEMARKER_SIDDHI_HOME_PAGE = "https://wso2.github.io/siddhi";
     public static final String FREEMARKER_SIDDHI_REPOSITORY_ARTIFACT_ID = "siddhi";
+    public static final String FREEMARKER_EXTENSION_REPOSITORY_PARENT_POSTFIX = "-parent";
 }

--- a/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/DocumentationUtils.java
+++ b/modules/siddhi-doc-gen/src/main/java/org/wso2/siddhi/doc/gen/core/utils/DocumentationUtils.java
@@ -22,6 +22,7 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -62,6 +63,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -331,22 +333,124 @@ public class DocumentationUtils {
     }
 
     /**
-     * Deploy the mkdocs website on GitHub pages
+     * Build the mkdocs site using the mkdocs config file
      *
      * @param mkdocsConfigFile The mkdocs configuration file
-     * @param version          The version of the documentation
      * @param logger           The maven logger
+     * @return true if the documentation generation is successful
      */
-    public static void deployMkdocsOnGitHubPages(File mkdocsConfigFile, String version, Log logger) {
+    public static boolean generateMkdocsSite(File mkdocsConfigFile, Log logger) {
+        boolean isDocumentationGenerationSuccessful = false;
         try {
+            // Building the mkdocs site
             executeCommand(new String[] {Constants.MKDOCS_COMMAND,
-                    Constants.MKDOCS_GITHUB_DEPLOY_COMMAND,
-                    Constants.MKDOCS_GITHUB_DEPLOY_COMMAND_CONFIG_FILE_ARGUMENT,
+                    Constants.MKDOCS_BUILD_COMMAND,
+                    Constants.MKDOCS_BUILD_COMMAND_CLEAN_ARGUEMENT,
+                    Constants.MKDOCS_BUILD_COMMAND_CONFIG_FILE_ARGUMENT,
                     mkdocsConfigFile.getAbsolutePath(),
-                    Constants.MKDOCS_GITHUB_DEPLOY_COMMAND_MESSAGE_ARGUMENT,
-                    String.format(Constants.GIT_COMMIT_COMMAND_MESSAGE_FORMAT, version, version)}, logger);
+                    Constants.MKDOCS_BUILD_COMMAND_SITE_DIRECTORY_ARGUMENT,
+                    Constants.MKDOCS_SITE_DIRECTORY}, logger);
+            isDocumentationGenerationSuccessful = true;
         } catch (Throwable t) {
-            logger.warn("Failed to execute mkdocs gh-deploy. Skipping deployment of documentation.", t);
+            logger.warn("Failed to generate the mkdocs site.", t);
+        }
+        return isDocumentationGenerationSuccessful;
+    }
+
+    /**
+     * Deploy the mkdocs website on GitHub pages
+     *
+     * @param version       The version of the documentation
+     * @param baseDirectory The base directory of the project
+     * @param scmUsername   The SCM username
+     * @param scmPassword   The SCM password
+     * @param logger        The maven logger
+     */
+    public static void deployMkdocsOnGitHubPages(String version, File baseDirectory, String scmUsername,
+                                                 String scmPassword, Log logger) {
+        try {
+            // Find initial branch name
+            List<String> gitStatusOutput = getCommandOutput(new String[]{Constants.GIT_COMMAND,
+                    Constants.GIT_BRANCH_COMMAND}, logger);
+            String initialBranch = null;
+            for (String gitStatusOutputLine : gitStatusOutput) {
+                if (gitStatusOutputLine.startsWith(Constants.GIT_BRANCH_COMMAND_OUTPUT_CURRENT_BRANCH_PREFIX)) {
+                    initialBranch = gitStatusOutputLine.substring(
+                            Constants.GIT_BRANCH_COMMAND_OUTPUT_CURRENT_BRANCH_PREFIX.length());
+                }
+            }
+
+            if (initialBranch != null) {
+                // Stash changes
+                executeCommand(new String[]{Constants.GIT_COMMAND,
+                        Constants.GIT_STASH_COMMAND}, logger);
+
+                // Change to gh-pages branch. This will not do anything if a new branch was created in the last command.
+                executeCommand(new String[]{Constants.GIT_COMMAND,
+                        Constants.GIT_CHECKOUT_COMMAND,
+                        Constants.GIT_GH_PAGES_BRANCH}, logger);
+
+                // Create branch if it does not exist. This will fail if the branch exists and will not do anything.
+                executeCommand(new String[]{Constants.GIT_COMMAND,
+                        Constants.GIT_CHECKOUT_COMMAND,
+                        Constants.GIT_CHECKOUT_COMMAND_ORPHAN_ARGUMENT,
+                        Constants.GIT_GH_PAGES_BRANCH}, logger);
+
+                executeCommand(new String[]{Constants.GIT_COMMAND,
+                        Constants.GIT_PULL_COMMAND,
+                        Constants.GIT_REMOTE,
+                        Constants.GIT_GH_PAGES_BRANCH}, logger);
+
+                // Getting the site that was built by mkdocs
+                File siteDirectory = new File(Constants.MKDOCS_SITE_DIRECTORY);
+                FileUtils.copyDirectory(siteDirectory, baseDirectory);
+                String[] siteDirectoryContent = siteDirectory.list();
+
+                // Pushing the site to GitHub (Assumes that site/ directory is ignored by git)
+                if (siteDirectoryContent != null && siteDirectoryContent.length > 0) {
+                    List<String> gitAddCommand = new ArrayList<>();
+                    Collections.addAll(gitAddCommand, Constants.GIT_COMMAND,
+                            Constants.GIT_ADD_COMMAND);
+                    Collections.addAll(gitAddCommand, siteDirectoryContent);
+                    executeCommand(gitAddCommand.toArray(new String[gitAddCommand.size()]), logger);
+
+                    List<String> gitCommitCommand = new ArrayList<>();
+                    Collections.addAll(gitCommitCommand, Constants.GIT_COMMAND,
+                            Constants.GIT_COMMIT_COMMAND,
+                            Constants.GIT_COMMIT_COMMAND_MESSAGE_ARGUMENT,
+                            String.format(Constants.GIT_COMMIT_COMMAND_MESSAGE_FORMAT, version, version),
+                            Constants.GIT_COMMIT_COMMAND_FILES_ARGUMENT);
+                    Collections.addAll(gitCommitCommand, siteDirectoryContent);
+                    executeCommand(gitCommitCommand.toArray(new String[gitCommitCommand.size()]), logger);
+
+                    if (scmUsername != null && scmPassword != null) {
+                        // Using scm username and password env var values
+                        executeCommand(new String[]{Constants.GIT_COMMAND,
+                                Constants.GIT_PUSH_COMMAND,
+                                String.format(Constants.GIT_REMOTE_WITH_USERNAME_PASSWORD, scmUsername, scmPassword),
+                                Constants.GIT_GH_PAGES_BRANCH}, logger);
+                    } else {
+                        // Using git credential store
+                        executeCommand(new String[]{Constants.GIT_COMMAND,
+                                Constants.GIT_PUSH_COMMAND,
+                                Constants.GIT_REMOTE,
+                                Constants.GIT_GH_PAGES_BRANCH}, logger);
+                    }
+                }
+
+                // Changing back to initial branch
+                executeCommand(new String[]{Constants.GIT_COMMAND,
+                        Constants.GIT_CHECKOUT_COMMAND,
+                        initialBranch}, logger);
+                executeCommand(new String[]{Constants.GIT_COMMAND,
+                        Constants.GIT_STASH_COMMAND,
+                        Constants.GIT_STASH_POP_COMMAND}, logger);
+            } else {
+                logger.warn("Unable to parse git-status command and retrieve current git branch. " +
+                        "Skipping deployment.");
+            }
+        } catch (Throwable t) {
+            logger.warn("Failed to deploy the documentation on github pages.", t);
         }
     }
 
@@ -364,17 +468,13 @@ public class DocumentationUtils {
         try {
             executeCommand(new String[] {Constants.GIT_COMMAND,
                     Constants.GIT_ADD_COMMAND,
-                    docsDirectory}, logger);
+                    docsDirectory, mkdocsConfigFile.getAbsolutePath(), readmeFile.getAbsolutePath()}, logger);
             executeCommand(new String[] {Constants.GIT_COMMAND,
                     Constants.GIT_COMMIT_COMMAND,
                     Constants.GIT_COMMIT_COMMAND_MESSAGE_ARGUMENT,
                     String.format(Constants.GIT_COMMIT_COMMAND_MESSAGE_FORMAT, version, version),
                     Constants.GIT_COMMIT_COMMAND_FILES_ARGUMENT,
                     docsDirectory, mkdocsConfigFile.getAbsolutePath(), readmeFile.getAbsolutePath()}, logger);
-            executeCommand(new String[] {Constants.GIT_COMMAND,
-                    Constants.GIT_PUSH_COMMAND,
-                    Constants.GIT_PUSH_COMMAND_REMOTE,
-                    Constants.GIT_PUSH_COMMAND_REMOTE_BRANCH}, logger);
         } catch (Throwable t) {
             logger.warn("Failed to update the documentation on GitHub repository", t);
         }
@@ -638,11 +738,13 @@ public class DocumentationUtils {
      *
      * @param command The command to be executed
      * @param logger  The maven plugin logger
+     * @return The output lines from executing the command
      * @throws Throwable if any error occurs during the execution of the command
      */
-    private static void executeCommand(String[] command, Log logger) throws Throwable {
+    private static List<String> getCommandOutput(String[] command, Log logger) throws Throwable {
         logger.info("Executing: " + String.join(" ", command));
         Process process = Runtime.getRuntime().exec(command);
+        List<String> executionOutputLines = new ArrayList<>();
 
         // Logging the output of the command execution
         InputStream[] inputStreams = new InputStream[] {process.getInputStream(), process.getErrorStream()};
@@ -657,12 +759,28 @@ public class DocumentationUtils {
                         break;
                     }
 
-                    logger.info(commandOutput);
+                    executionOutputLines.add(commandOutput);
                 }
             }
             process.waitFor();
         } finally {
             IOUtils.closeQuietly(bufferedReader);
+        }
+
+        return executionOutputLines;
+    }
+
+    /**
+     * Executing a command.
+     *
+     * @param command The command to be executed
+     * @param logger  The maven plugin logger
+     * @throws Throwable if any error occurs during the execution of the command
+     */
+    private static void executeCommand(String[] command, Log logger) throws Throwable {
+        List<String> executionOutputLines = getCommandOutput(command, logger);
+        for (String executionOutputLine : executionOutputLines) {
+            logger.debug(executionOutputLine);
         }
     }
 }

--- a/modules/siddhi-doc-gen/src/main/resources/templates/headings-update.md.ftl
+++ b/modules/siddhi-doc-gen/src/main/resources/templates/headings-update.md.ftl
@@ -21,7 +21,7 @@
     <#assign repositoryOwner = "wso2">
 <#else>
     <#assign repositoryOwner = "wso2-extensions">
-    <#assign extensionRepositoryName = extensionRepositoryName?replace(CONSTANTS.GITHUB_EXTENSION_REPOSITORY_PARENT_POSTFIX, "", "r")>
+    <#assign extensionRepositoryName = extensionRepositoryName?replace(CONSTANTS.FREEMARKER_EXTENSION_REPOSITORY_PARENT_POSTFIX, "", "r")>
 </#if>
 <#macro renderLine line>
 ${line}


### PR DESCRIPTION
Re-implementing #519 with the following changes to it
* Retrieving SCM username and password from the environment variables.
* Changing back to the initial branch the build was running in, rather than the master branch, after running the "deploy-mkdocs-github-pages" goal.