### PR TITLE
Make SinkHandler and SourceHandler Snapshotable

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -300,7 +300,7 @@ public class SiddhiAppRuntime {
             for (Source source : sources) {
                 try {
                     if (sourceHandlerManager != null) {
-                        sourceHandlerManager.unregisterSourceHandler(source.getElementId());
+                        sourceHandlerManager.unregisterSourceHandler(source.getMapper().getHandler().getElementId());
                     }
                     source.shutdown();
                 } catch (Throwable t) {
@@ -329,7 +329,7 @@ public class SiddhiAppRuntime {
             for (Sink sink : sinks) {
                 try {
                     if (sinkHandlerManager != null) {
-                        sinkHandlerManager.unregisterSinkHandler(sink.getElementId());
+                        sinkHandlerManager.unregisterSinkHandler(sink.getHandler().getElementId());
                     }
                     sink.shutdown();
                 } catch (Throwable t) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/Source.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/Source.java
@@ -66,7 +66,7 @@ public abstract class Source implements Snapshotable {
         this.elementId = siddhiAppContext.getElementIdGenerator().createNewId();
         this.siddhiAppContext = siddhiAppContext;
         if (sourceHandler != null) {
-            sourceHandler.initSourceHandler(elementId, streamDefinition);
+            sourceHandler.initSourceHandler(siddhiAppContext.getElementIdGenerator().createNewId(), streamDefinition);
         }
         init(sourceMapper, transportOptionHolder, transportPropertyNames, configReader, siddhiAppContext);
         scheduledExecutorService = siddhiAppContext.getScheduledExecutorService();

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceHandler.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceHandler.java
@@ -19,23 +19,24 @@
 package org.wso2.siddhi.core.stream.input.source;
 
 import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.util.snapshot.Snapshotable;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
 /**
  * SourceHandler is an optional implementable class that wraps {@link org.wso2.siddhi.core.stream.input.InputHandler}.
  * It will do optional processing to the events before sending the events to the input handler
  */
-public abstract class SourceHandler implements InputEventHandler {
+public abstract class SourceHandler implements InputEventHandler, Snapshotable {
 
     private InputEventHandlerImpl inputEventHandlerImpl;
-    private String sourceElementId;
+    private String elementId;
 
-    final void initSourceHandler(String sourceElementId, StreamDefinition streamDefinition) {
-        this.sourceElementId = sourceElementId;
-        init(sourceElementId, streamDefinition);
+    final void initSourceHandler(String elementId, StreamDefinition streamDefinition) {
+        this.elementId = elementId;
+        init(elementId, streamDefinition);
     }
 
-    public abstract void init(String sourceElementId, StreamDefinition streamDefinition);
+    public abstract void init(String elementId, StreamDefinition streamDefinition);
 
     final void setInputEventHandlerImpl(InputEventHandlerImpl inputEventHandlerImpl) {
         this.inputEventHandlerImpl = inputEventHandlerImpl;
@@ -55,7 +56,7 @@ public abstract class SourceHandler implements InputEventHandler {
 
     public abstract void handle(Event[] events, InputEventHandler inputEventHandler) throws InterruptedException;
 
-    String getSourceElementId() {
-        return sourceElementId;
+    public String getElementId() {
+        return elementId;
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/Sink.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/Sink.java
@@ -70,7 +70,8 @@ public abstract class Sink implements SinkListener, Snapshotable {
             this.mapper = sinkMapper;
         }
         if (sinkHandler != null) {
-            sinkHandler.init(elementId, streamDefinition, new SinkHandlerCallback(sinkMapper));
+            sinkHandler.init(siddhiAppContext.getElementIdGenerator().createNewId(), streamDefinition,
+                    new SinkHandlerCallback(sinkMapper));
             this.handler = sinkHandler;
         }
         scheduledExecutorService = siddhiAppContext.getScheduledExecutorService();

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkHandler.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkHandler.java
@@ -19,24 +19,25 @@
 package org.wso2.siddhi.core.stream.output.sink;
 
 import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.util.snapshot.Snapshotable;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
 /**
  * SinkHandler is an optional interface before {@link SinkMapper}.
  * It will do optional processing to the events before sending the events to the desired mapper
  */
-public abstract class SinkHandler {
+public abstract class SinkHandler implements Snapshotable {
 
     private SinkHandlerCallback sinkHandlerCallback;
-    private String sinkElementId;
+    private String elementId;
 
-    final void init(String sinkElementId, StreamDefinition streamDefinition, SinkHandlerCallback sinkHandlerCallback) {
+    final void init(String elementId, StreamDefinition streamDefinition, SinkHandlerCallback sinkHandlerCallback) {
         this.sinkHandlerCallback = sinkHandlerCallback;
-        this.sinkElementId = sinkElementId;
-        init(sinkElementId, streamDefinition);
+        this.elementId = elementId;
+        init(elementId, streamDefinition);
     }
 
-    public abstract void init(String sinkElementId, StreamDefinition streamDefinition);
+    public abstract void init(String elementId, StreamDefinition streamDefinition);
 
     public void handle(Event event) {
         handle(event, sinkHandlerCallback);
@@ -50,7 +51,7 @@ public abstract class SinkHandler {
 
     public abstract void handle(Event[] events, SinkHandlerCallback sinkHandlerCallback);
 
-    String getSinkElementId() {
-        return sinkElementId;
+    public String getElementId() {
+        return elementId;
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -335,7 +335,8 @@ public class DefinitionParserHelper {
 
                     siddhiAppContext.getSnapshotService().addSnapshotable(source.getStreamDefinition().getId(), source);
                     if (sourceHandlerManager != null) {
-                        sourceHandlerManager.registerSourceHandler(source.getElementId(), sourceHandler);
+                        sourceHandlerManager.registerSourceHandler(sourceHandler.getElementId(), sourceHandler);
+                        siddhiAppContext.getSnapshotService().addSnapshotable(streamDefinition.getId(), sourceHandler);
                     }
                     List<Source> eventSources = eventSourceMap.get(streamDefinition.getId());
                     if (eventSources == null) {
@@ -503,7 +504,9 @@ public class DefinitionParserHelper {
                         }
 
                         if (sinkHandlerManager != null) {
-                            sinkHandlerManager.registerSinkHandler(sink.getElementId(), sinkHandler);
+                            sinkHandlerManager.registerSinkHandler(sinkHandler.getElementId(), sinkHandler);
+                            siddhiAppContext.getSnapshotService().addSnapshotable(streamDefinition.getId(),
+                                    sinkHandler);
                         }
 
                         validateSinkMapperCompatibility(streamDefinition, sinkType, mapType, sink, sinkMapper,


### PR DESCRIPTION
## Purpose
> So that the states of SinkHandler and SourceHandler can be persisted and restored

## Goals
> This feature can be used in SP 2 node HA Sync States

## Approach
> Implement Snapshotable interface, register with snapshot service