### PR TITLE
Adding methods to expose SiddhiApp statistics details

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -516,11 +516,11 @@ public class SiddhiAppRuntime {
     }
 
     /**
-     * Get the Siddhi App matric prefix.
+     * Get the Siddhi App metric prefix.
      *
-     * @return Siddhi App matric prefix.
+     * @return Siddhi App metric prefix.
      */
-    public String getSidhhiAppMatricPrefix() {
+    public String getSidhhiAppMetricPrefix() {
         return siddhiAppContext.getSiddhiContext().getStatisticsConfiguration().getMatricPrefix();
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -505,4 +505,27 @@ public class SiddhiAppRuntime {
     public void handleExceptionWith(ExceptionHandler<Object> exceptionHandler) {
         siddhiAppContext.setDisruptorExceptionHandler(exceptionHandler);
     }
+
+    /**
+     * Method to check whether the Siddhi App statistics are enabled or not.
+     *
+     * @return Boolean value of Siddhi App statistics state
+     */
+    public boolean isSiddhiAppStatEnabled() {
+        return siddhiAppContext.isStatsEnabled();
+    }
+
+    /**
+     * Get the Siddhi App matric prefix.
+     *
+     * @return Siddhi App matric prefix.
+     */
+    public String getSidhhiAppMatricPrefix() {
+        return siddhiAppContext.getSiddhiContext().getStatisticsConfiguration().getMatricPrefix();
+    }
+
+    public boolean disableSiddhiAppStats() {
+        // TODO: 10/18/17
+        return false;
+    }
 }


### PR DESCRIPTION
## Purpose
> To expose SiddhiApp statistics details in SiddhiAppRuntime.

## Approach
> Add a method to get SiddhiApp statistics state.
Add a method to get SiddhApp matric prefix.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes