### PR TITLE
Removing unused output event types from grammar file

### DIFF
--- a/modules/siddhi-query-compiler/src/main/antlr4/org/wso2/siddhi/query/compiler/SiddhiQL.g4
+++ b/modules/siddhi-query-compiler/src/main/antlr4/org/wso2/siddhi/query/compiler/SiddhiQL.g4
@@ -388,7 +388,7 @@ set_assignment
     ;
 
 output_event_type
-    : ALL EVENTS | ALL RAW EVENTS | EXPIRED EVENTS | EXPIRED RAW EVENTS | CURRENT? EVENTS   
+    : ALL EVENTS | EXPIRED EVENTS | CURRENT? EVENTS   
     ;
 
 output_rate

--- a/modules/siddhi-query-compiler/src/main/java/org/wso2/siddhi/query/compiler/internal/SiddhiQLBaseVisitorImpl.java
+++ b/modules/siddhi-query-compiler/src/main/java/org/wso2/siddhi/query/compiler/internal/SiddhiQLBaseVisitorImpl.java
@@ -1735,21 +1735,13 @@ public class SiddhiQLBaseVisitorImpl extends SiddhiQLBaseVisitor {
     @Override
     public OutputStream.OutputEventType visitOutput_event_type(@NotNull SiddhiQLParser.Output_event_typeContext ctx) {
 //        output_event_type
-//        : ALL EVENTS | ALL RAW EVENTS | EXPIRED EVENTS | EXPIRED RAW EVENTS | CURRENT? EVENTS
+//        : ALL EVENTS | EXPIRED EVENTS | CURRENT? EVENTS
 //        ;
 
         if (ctx.ALL() != null) {
-            if (ctx.RAW() != null) {
-                return OutputStream.OutputEventType.ALL_RAW_EVENTS;
-            } else {
                 return OutputStream.OutputEventType.ALL_EVENTS;
-            }
         } else if (ctx.EXPIRED() != null) {
-            if (ctx.RAW() != null) {
-                return OutputStream.OutputEventType.EXPIRED_RAW_EVENTS;
-            } else {
                 return OutputStream.OutputEventType.EXPIRED_EVENTS;
-            }
         } else {
             return OutputStream.OutputEventType.CURRENT_EVENTS;
         }


### PR DESCRIPTION
## Purpose
This PR removes unused output event types from grammar file

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

