### PR TITLE
fix class cast exception

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/transport/Option.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/transport/Option.java
@@ -69,7 +69,7 @@ public class Option {
         } else if (templateBuilder != null) {
             return (String) templateBuilder.build(dynamicOptions.getEvent());
         } else if (dataIndex != -1) {
-            return (String) dynamicOptions.getEvent().getData(dataIndex);
+            return String.valueOf(dynamicOptions.getEvent().getData(dataIndex));
         } else {
             return null;
         }
@@ -81,7 +81,7 @@ public class Option {
         } else if (templateBuilder != null) {
             return (String) templateBuilder.build(event);
         } else if (dataIndex != -1) {
-            return (String) event.getData(dataIndex);
+            return String.valueOf(event.getData(dataIndex));
         } else {
             return null;
         }


### PR DESCRIPTION
## Purpose
To fix possible Class cast exception

## Goals
Use String.ValueOf instead of direct casting

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8.0
