### PR TITLE
Fixed 'NullPointerException' issue in FilterProcessor.

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/filter/FilterProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/filter/FilterProcessor.java
@@ -51,7 +51,8 @@ public class FilterProcessor implements Processor {
         complexEventChunk.reset();
         while (complexEventChunk.hasNext()) {
             ComplexEvent complexEvent = complexEventChunk.next();
-            if (!(Boolean) conditionExecutor.execute(complexEvent)) {
+            Object result = conditionExecutor.execute(complexEvent);
+            if (result == null || !(Boolean) result) {
                 complexEventChunk.remove();
             }
         }


### PR DESCRIPTION
## Purpose
> When a boolean type attribute is used as Siddhi filter expression there is a possibility of 'NullPointerException'. So this simple change is done to avoid it.


