### PR TITLE
Adding timeLength as an inbuilt window

### DIFF
--- a/docs/documentation/siddhi-4.0.md
+++ b/docs/documentation/siddhi-4.0.md
@@ -721,6 +721,7 @@ Following are some inbuilt windows shipped with Siddhi. For more window types, s
 
 * time
 * timeBatch
+* timeLength
 * length
 * lengthBatch
 * sort


### PR DESCRIPTION
## Purpose
Adding missing timeLength as an inbuilt window

## Goals
N/A

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
  N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A