### PR TITLE
Fix markdown issues in mkdocs

### DIFF
--- a/docs/documentation/siddhi-4.0.md
+++ b/docs/documentation/siddhi-4.0.md
@@ -1971,18 +1971,17 @@ The following types of triggeres are currently supported:
 
     The following query triggers events every 5 minutes.
     
-    ```sql
+```sql
      define trigger FiveMinTriggerStream at every 5 min;
-    ```
+```
 
 + Triggering events at a specific time on specified days
 
     The following query triggers an event at 10.15 AM on every weekdays.
     
-    ```sql
+```sql
      define trigger FiveMinTriggerStream at '0 15 10 ? * MON-FRI';
-     
-    ```
+```
 
 ## Script
 


### PR DESCRIPTION
## Purpose
github code mark down is not properly working in mkdocs when spaces are present infront. This PR fix that issue by removing those spaces