### PR TITLE
Fix restoring state of updated siddhi app

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -24,6 +24,7 @@ import org.wso2.siddhi.core.aggregation.AggregationRuntime;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
 import org.wso2.siddhi.core.debugger.SiddhiDebugger;
 import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.exception.DefinitionNotExistException;
 import org.wso2.siddhi.core.exception.QueryNotExistException;
 import org.wso2.siddhi.core.exception.StoreQueryCreationException;
@@ -458,7 +459,7 @@ public class SiddhiAppRuntime {
         }
     }
 
-    public void restore(byte[] snapshot) {
+    public void restore(byte[] snapshot) throws CannotRestoreSiddhiAppStateException {
         try {
             // first, pause all the event sources
             sourceMap.values().forEach(list -> list.forEach(Source::pause));
@@ -470,7 +471,7 @@ public class SiddhiAppRuntime {
         }
     }
 
-    public void restoreRevision(String revision) {
+    public void restoreRevision(String revision) throws CannotRestoreSiddhiAppStateException {
         try {
             // first, pause all the event sources
             sourceMap.values().forEach(list -> list.forEach(Source::pause));
@@ -482,7 +483,7 @@ public class SiddhiAppRuntime {
         }
     }
 
-    public String restoreLastRevision() {
+    public String restoreLastRevision() throws CannotRestoreSiddhiAppStateException {
         String revision;
         try {
             // first, pause all the event sources

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiManager.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiManager.java
@@ -20,6 +20,7 @@ package org.wso2.siddhi.core;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiContext;
 import org.wso2.siddhi.core.config.StatisticsConfiguration;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.stream.input.source.SourceHandlerManager;
 import org.wso2.siddhi.core.stream.output.sink.SinkHandlerManager;
 import org.wso2.siddhi.core.table.record.RecordTableHandlerManager;
@@ -227,7 +228,11 @@ public class SiddhiManager {
      */
     public void restoreLastState() {
         for (SiddhiAppRuntime siddhiAppRuntime : siddhiAppRuntimeMap.values()) {
-            siddhiAppRuntime.restoreLastRevision();
+            try {
+                siddhiAppRuntime.restoreLastRevision();
+            } catch (CannotRestoreSiddhiAppStateException e) {
+                log.error("Error in restoring Siddhi app " + siddhiAppRuntime.getName(), e);
+            }
         }
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/exception/CannotRestoreSiddhiAppStateException.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/exception/CannotRestoreSiddhiAppStateException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.exception;
+
+/**
+ * Exception class to be used when Siddhi app can not restore state properly.
+ */
+public class CannotRestoreSiddhiAppStateException extends Exception {
+
+    public CannotRestoreSiddhiAppStateException() {
+        super();
+    }
+
+    public CannotRestoreSiddhiAppStateException(String message) {
+        super(message);
+    }
+
+    public CannotRestoreSiddhiAppStateException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public CannotRestoreSiddhiAppStateException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/PersistenceService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/PersistenceService.java
@@ -19,6 +19,7 @@ package org.wso2.siddhi.core.util.persistence;
 
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.exception.NoPersistenceStoreException;
 import org.wso2.siddhi.core.util.snapshot.SnapshotService;
 
@@ -60,7 +61,7 @@ public class PersistenceService {
 
     }
 
-    public void restoreRevision(String revision) {
+    public void restoreRevision(String revision) throws CannotRestoreSiddhiAppStateException {
         if (persistenceStore != null) {
             if (log.isDebugEnabled()) {
                 log.debug("Restoring revision: " + revision + " ...");
@@ -76,7 +77,7 @@ public class PersistenceService {
         }
     }
 
-    public String restoreLastRevision() {
+    public String restoreLastRevision() throws CannotRestoreSiddhiAppStateException {
         if (persistenceStore != null) {
             String revision = persistenceStore.getLastRevision(siddhiAppName);
             if (revision != null) {
@@ -89,7 +90,7 @@ public class PersistenceService {
         }
     }
 
-    public void restore(byte[] snapshot) {
+    public void restore(byte[] snapshot) throws CannotRestoreSiddhiAppStateException {
         snapshotService.restore(snapshot);
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
@@ -125,7 +125,13 @@ public class SnapshotService {
             for (Map.Entry<String, List<Snapshotable>> entry : snapshotableMap.entrySet()) {
                 snapshotableList = entry.getValue();
                 for (Snapshotable snapshotable : snapshotableList) {
-                    snapshotable.restoreState(snapshots.get(snapshotable.getElementId()));
+                    try {
+                        snapshotable.restoreState(snapshots.get(snapshotable.getElementId()));
+                    } catch (Throwable t) {
+                        log.error("State if Siddhi app " + siddhiAppContext.getName() + " not restored properly " +
+                                "because the Siddhi app may have changed since the last persist. Clean the old " +
+                                "revisions from the database/file system for a fresh deployment of Siddhi app");
+                    }
                 }
             }
         } finally {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
@@ -19,6 +19,7 @@ package org.wso2.siddhi.core.util.snapshot;
 
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.util.ThreadBarrier;
 
 import java.util.ArrayList;
@@ -115,8 +116,7 @@ public class SnapshotService {
 
     }
 
-
-    public void restore(byte[] snapshot) {
+    public void restore(byte[] snapshot) throws CannotRestoreSiddhiAppStateException {
         Map<String, Map<String, Object>> snapshots = (Map<String, Map<String, Object>>)
                 ByteSerializer.byteToObject(snapshot, siddhiAppContext);
         List<Snapshotable> snapshotableList;
@@ -124,14 +124,14 @@ public class SnapshotService {
             threadBarrier.lock();
             for (Map.Entry<String, List<Snapshotable>> entry : snapshotableMap.entrySet()) {
                 snapshotableList = entry.getValue();
-                for (Snapshotable snapshotable : snapshotableList) {
-                    try {
+                try {
+                    for (Snapshotable snapshotable : snapshotableList) {
                         snapshotable.restoreState(snapshots.get(snapshotable.getElementId()));
-                    } catch (Throwable t) {
-                        log.error("State if Siddhi app " + siddhiAppContext.getName() + " not restored properly " +
-                                "because the Siddhi app may have changed since the last persist. Clean the old " +
-                                "revisions from the database/file system for a fresh deployment of Siddhi app");
                     }
+                } catch (Throwable t) {
+                    throw new CannotRestoreSiddhiAppStateException("Restoring of Siddhi app " + siddhiAppContext.
+                            getName() + " not completed properly because content of Siddhi app has changed since " +
+                            "last state persistence. Clean persistence store for a fresh deployment.", t);
                 }
             }
         } finally {

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/managment/PersistenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/managment/PersistenceTestCase.java
@@ -19,12 +19,14 @@
 package org.wso2.siddhi.core.managment;
 
 import org.apache.log4j.Logger;
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.exception.NoPersistenceStoreException;
 import org.wso2.siddhi.core.query.output.callback.QueryCallback;
 import org.wso2.siddhi.core.stream.input.InputHandler;
@@ -119,7 +121,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 100});
         Thread.sleep(10);
@@ -200,7 +206,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         stream2.send(new Object[]{"IBM", 45.7f, 100});
         Thread.sleep(500);
@@ -344,7 +354,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         //shutdown siddhi app
         Thread.sleep(500);
@@ -426,7 +440,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         //shutdown siddhi app
         Thread.sleep(15000);
@@ -500,7 +518,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 100});
         Thread.sleep(100);
@@ -584,7 +606,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"IBM", 75.4f, 100, currentTime + 4000});
         Thread.sleep(100);
@@ -664,7 +690,11 @@ public class PersistenceTestCase {
         siddhiAppRuntime.start();
 
         //loading
-        siddhiAppRuntime.restore(snapshot);
+        try {
+            siddhiAppRuntime.restore(snapshot);
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 100});
         Thread.sleep(10);
@@ -689,7 +719,7 @@ public class PersistenceTestCase {
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setPersistenceStore(persistenceStore);
 
-        String executionPlan = "" +
+        String siddhiApp = "" +
                 "@app:name('Test') " +
                 "" +
                 "define stream StockStream ( symbol string, price float, volume long );" +
@@ -716,11 +746,11 @@ public class PersistenceTestCase {
             }
         };
 
-        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(executionPlan);
-        executionPlanRuntime.addCallback("query1", queryCallback);
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("query1", queryCallback);
 
-        InputHandler inputHandler = executionPlanRuntime.getInputHandler("StockStream");
-        executionPlanRuntime.start();
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 100L});
         inputHandler.send(new Object[]{"WSO2", 75.6f, 101L});
@@ -732,20 +762,24 @@ public class PersistenceTestCase {
         AssertJUnit.assertTrue(eventArrived);
 
         //persisting
-        executionPlanRuntime.persist();
+        siddhiAppRuntime.persist();
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 105L});
         inputHandler.send(new Object[]{"WSO2", 75.6f, 106L});
         Thread.sleep(50);
         //restarting execution plan
-        executionPlanRuntime.shutdown();
-        executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(executionPlan);
-        executionPlanRuntime.addCallback("query1", queryCallback);
-        inputHandler = executionPlanRuntime.getInputHandler("StockStream");
-        executionPlanRuntime.start();
+        siddhiAppRuntime.shutdown();
+        siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("query1", queryCallback);
+        inputHandler = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
 
         //loading
-        executionPlanRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 107L});
         inputHandler.send(new Object[]{"IBM", 75.6f, 108L});
@@ -754,8 +788,8 @@ public class PersistenceTestCase {
         SiddhiTestHelper.waitForEvents(100, 7, atomicCount, 10000);
         AssertJUnit.assertEquals(7, atomicCount.get());
 
-        //shutdown execution plan
-        executionPlanRuntime.shutdown();
+        //shutdown siddhi app
+        siddhiAppRuntime.shutdown();
     }
 
     @Test(dependsOnMethods = "persistenceTest9")
@@ -766,7 +800,7 @@ public class PersistenceTestCase {
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setPersistenceStore(persistenceStore);
 
-        String executionPlan = "" +
+        String siddhiApp = "" +
                 "@app:name('Test') " +
                 "" +
                 "define stream StockStream ( symbol string, price float, volume int );" +
@@ -776,7 +810,7 @@ public class PersistenceTestCase {
                 "select volume " +
                 "insert all events into outputStream ;";
 
-        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(executionPlan);
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
         QueryCallback queryCallback = new QueryCallback() {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
@@ -794,10 +828,10 @@ public class PersistenceTestCase {
                 }
             }
         };
-        executionPlanRuntime.addCallback("query1", queryCallback);
+        siddhiAppRuntime.addCallback("query1", queryCallback);
 
-        InputHandler inputHandler = executionPlanRuntime.getInputHandler("StockStream");
-        executionPlanRuntime.start();
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
         inputHandler.send(new Object[]{"WSO2", 55.6f, 100});
         inputHandler.send(new Object[]{"IBM", 75.6f, 300});
         inputHandler.send(new Object[]{"WSO2", 57.6f, 200});
@@ -806,26 +840,30 @@ public class PersistenceTestCase {
         AssertJUnit.assertEquals(3, count);
         AssertJUnit.assertTrue(eventArrived);
         // persisting
-        executionPlanRuntime.persist();
+        siddhiAppRuntime.persist();
 
         inputHandler.send(new Object[]{"WSO2", 55.6f, 20});
         inputHandler.send(new Object[]{"WSO2", 57.6f, 40});
 
         Thread.sleep(500);
-        executionPlanRuntime.shutdown();
-        executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(executionPlan);
-        executionPlanRuntime.addCallback("query1", queryCallback);
-        inputHandler = executionPlanRuntime.getInputHandler("StockStream");
-        executionPlanRuntime.start();
+        siddhiAppRuntime.shutdown();
+        siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("query1", queryCallback);
+        inputHandler = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
         //loading
-        executionPlanRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"WSO2", 55.6f, 20});
 
         SiddhiTestHelper.waitForEvents(100, 6, atomicCount, 10000);
         AssertJUnit.assertEquals(true, eventArrived);
         AssertJUnit.assertEquals(200, lastValueRemoved);
-        executionPlanRuntime.shutdown();
+        siddhiAppRuntime.shutdown();
 
     }
 
@@ -837,7 +875,7 @@ public class PersistenceTestCase {
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setPersistenceStore(persistenceStore);
 
-        String executionPlan = "" +
+        String siddhiApp = "" +
                 "@app:name('Test') " +
                 "" +
                 "define stream StockStream ( symbol string, price float, volume long );" +
@@ -866,11 +904,11 @@ public class PersistenceTestCase {
             }
         };
 
-        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(executionPlan);
-        executionPlanRuntime.addCallback("query1", queryCallback);
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("query1", queryCallback);
 
-        InputHandler inputHandler = executionPlanRuntime.getInputHandler("StockStream");
-        executionPlanRuntime.start();
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 100L});
         inputHandler.send(new Object[]{"WSO2", 75.6f, 101L});
@@ -881,7 +919,7 @@ public class PersistenceTestCase {
         AssertJUnit.assertEquals(new Long(101), lastValue);
 
         //persisting
-        executionPlanRuntime.persist();
+        siddhiAppRuntime.persist();
         Thread.sleep(500);
 
         inputHandler.send(new Object[]{"WSO2", 75.6f, 50L});
@@ -890,22 +928,26 @@ public class PersistenceTestCase {
 
         //restarting execution plan
         Thread.sleep(500);
-        executionPlanRuntime.shutdown();
-        executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(executionPlan);
-        executionPlanRuntime.addCallback("query1", queryCallback);
-        inputHandler = executionPlanRuntime.getInputHandler("StockStream");
-        executionPlanRuntime.start();
+        siddhiAppRuntime.shutdown();
+        siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("query1", queryCallback);
+        inputHandler = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
 
         //loading
-        executionPlanRuntime.restoreLastRevision();
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
 
         inputHandler.send(new Object[]{"IBM", 75.6f, 100L});
 
-        //shutdown execution plan
+        //shutdown siddhi app
         Thread.sleep(500);
         SiddhiTestHelper.waitForEvents(100, 3, atomicCount, 10000);
         AssertJUnit.assertEquals(new Long(103), lastValue);
-        executionPlanRuntime.shutdown();
+        siddhiAppRuntime.shutdown();
     }
 
 }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/partition/PartitionTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/partition/PartitionTestCase.java
@@ -18,12 +18,14 @@
 package org.wso2.siddhi.core.query.partition;
 
 import org.apache.log4j.Logger;
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
@@ -1904,7 +1906,11 @@ public class PartitionTestCase {
         byte[] snapshot = siddhiAppRuntime.snapshot();
         siddhiAppRuntime.shutdown();
         Thread.sleep(1000);
-        siddhiAppRuntime2.restore(snapshot);
+        try {
+            siddhiAppRuntime2.restore(snapshot);
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
         siddhiAppRuntime2.start();
         inputHandlerB.send(new Event(System.currentTimeMillis(), new Object[]{"IBM",  700}));
         inputHandlerB.send(new Event(System.currentTimeMillis(), new Object[]{"WSO2",  60}));


### PR DESCRIPTION
## Purpose
> Null pointer thrown when restoring a siddhi app when its content changed after state is persisted

## Goals
> Fix issue null pointer being thrown when siddhi app content changes and restoring from an old revision

## Approach
> Catch throwable at snapshot service level and thrown a checked exception.
> Refactor test cases to handle the thrown exception

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes