### PR TITLE
Pass SinkHandlerCallback down

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/Sink.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/Sink.java
@@ -85,7 +85,7 @@ public abstract class Sink implements SinkListener, Snapshotable {
             this.mapper = sinkMapper;
         }
         if (sinkHandler != null) {
-            sinkHandler.init(siddhiAppContext.getElementIdGenerator().createNewId(), streamDefinition,
+            sinkHandler.initSinkHandler(siddhiAppContext.getElementIdGenerator().createNewId(), streamDefinition,
                     new SinkHandlerCallback(sinkMapper));
             this.handler = sinkHandler;
         }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkHandler.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/SinkHandler.java
@@ -31,13 +31,15 @@ public abstract class SinkHandler implements Snapshotable {
     private SinkHandlerCallback sinkHandlerCallback;
     private String elementId;
 
-    final void init(String elementId, StreamDefinition streamDefinition, SinkHandlerCallback sinkHandlerCallback) {
+    final void initSinkHandler(String elementId, StreamDefinition streamDefinition,
+                               SinkHandlerCallback sinkHandlerCallback) {
         this.sinkHandlerCallback = sinkHandlerCallback;
         this.elementId = elementId;
-        init(elementId, streamDefinition);
+        init(elementId, streamDefinition, sinkHandlerCallback);
     }
 
-    public abstract void init(String elementId, StreamDefinition streamDefinition);
+    public abstract void init(String elementId, StreamDefinition streamDefinition,
+                              SinkHandlerCallback sinkHandlerCallback);
 
     public void handle(Event event) {
         handle(event, sinkHandlerCallback);


### PR DESCRIPTION
## Purpose
> Passing sinkHandlerCallback down so that in when implementing SinkHandler, callback can be used to send publish events

## Approach
> Pass the sinkHandlerCallback instance to the abstract init method in SinkHandler

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes