### PR TITLE
Make InMemoryTable be able to be persisted

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/IndexEventHolder.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/IndexEventHolder.java
@@ -28,6 +28,7 @@ import org.wso2.siddhi.core.exception.OperationNotSupportedException;
 import org.wso2.siddhi.core.util.SiddhiConstants;
 import org.wso2.siddhi.query.api.expression.condition.Compare;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,7 +42,7 @@ import java.util.TreeMap;
  * EventHolder implementation where events will be indexed and stored. This will offer faster access compared to
  * other EventHolder implementations. User can only add unique events based on a given primary key.
  */
-public class IndexEventHolder implements IndexedEventHolder {
+public class IndexEventHolder implements IndexedEventHolder, Serializable {
 
     private static final Logger log = Logger.getLogger(IndexEventHolder.class);
     private final Map<Object, StreamEvent> primaryKeyData;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/IndexEventHolder.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/IndexEventHolder.java
@@ -45,6 +45,7 @@ import java.util.TreeMap;
 public class IndexEventHolder implements IndexedEventHolder, Serializable {
 
     private static final Logger log = Logger.getLogger(IndexEventHolder.class);
+    private static final long serialVersionUID = 1272291743721603253L;
     private final Map<Object, StreamEvent> primaryKeyData;
     private final Map<String, TreeMap<Object, Set<StreamEvent>>> indexData;
     private final PrimaryKeyReferenceHolder[] primaryKeyReferenceHolders;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/PrimaryKeyReferenceHolder.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/PrimaryKeyReferenceHolder.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
  * PrimaryKeyReferenceHolder for indexed Event Table
  */
 public class PrimaryKeyReferenceHolder implements Serializable {
+    private static final long serialVersionUID = 3147984326180029463L;
     private String primaryKeyAttribute = null;
     private int primaryKeyPosition = -1;
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/PrimaryKeyReferenceHolder.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/holder/PrimaryKeyReferenceHolder.java
@@ -18,10 +18,12 @@
 
 package org.wso2.siddhi.core.table.holder;
 
+import java.io.Serializable;
+
 /**
  * PrimaryKeyReferenceHolder for indexed Event Table
  */
-public class PrimaryKeyReferenceHolder {
+public class PrimaryKeyReferenceHolder implements Serializable {
     private String primaryKeyAttribute = null;
     private int primaryKeyPosition = -1;
 


### PR DESCRIPTION
## Purpose
> Fix Issue #677 

## Goals
> Make InMemoryTable be able to be persisted

## Approach
> Made PrimaryKeyReferenceHolder and IndexEventHolder Serializable

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
>  N/A

## Related PRs
>  N/A

## Migrations (if applicable)
>  N/A

## Test environment
> Ubuntu 16.04
 
## Learning
>  N/A