### PR TITLE
Fixing issue #675 not optimizing output data

### DIFF
--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v4.0.0-beta3
+# API Docs - v4.0.0-beta4-SNAPSHOT
 
 ## Core
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
@@ -103,7 +103,7 @@ public class AggregationRuntime implements MemoryCalculable {
         this.throughputTrackerFind = throughputTrackerFind;
 
         aggregateMetaSteamEvent = new MetaStreamEvent();
-        aggregationDefinition.getAttributeList().forEach(aggregateMetaSteamEvent::addOutputData);
+        aggregationDefinition.getAttributeList().forEach(aggregateMetaSteamEvent::addOutputDataIfNotExist);
     }
 
     private static void initMetaStreamEvent(MetaStreamEvent metaStreamEvent, AbstractDefinition inputDefinition) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/MetaStreamEvent.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/MetaStreamEvent.java
@@ -89,6 +89,15 @@ public class MetaStreamEvent implements MetaComplexEvent {
         return SiddhiConstants.UNKNOWN_STATE;
     }
 
+    public void addOutputDataIfNotExist(Attribute attribute) {
+        if (outputData == null) {
+            outputData = new ArrayList<Attribute>();
+        }
+        if (!outputData.contains(attribute)) {
+            outputData.add(attribute);
+        }
+    }
+
     public void addOutputData(Attribute attribute) {
         if (outputData == null) {
             outputData = new ArrayList<Attribute>();

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
@@ -147,7 +147,7 @@ public class AggregationParser {
             MetaStreamEvent processedMetaStreamEvent = new MetaStreamEvent();
             for (Attribute attribute : incomingMetaStreamEvent.getOutputData()) {
                 incomingOutputStreamDefinition.attribute(attribute.getName(), attribute.getType());
-                processedMetaStreamEvent.addOutputData(attribute);
+                processedMetaStreamEvent.addOutputDataIfNotExist(attribute);
             }
             incomingMetaStreamEvent.setOutputDefinition(incomingOutputStreamDefinition);
             processedMetaStreamEvent.addInputDefinition(incomingOutputStreamDefinition);
@@ -362,7 +362,7 @@ public class AggregationParser {
                 if (!finalBaseAttributes.contains(baseAttributes[i])) {
                     finalBaseAttributes.add(baseAttributes[i]);
                     finalBaseAggregators.add(baseAggregators[i]);
-                    incomingMetaStreamEvent.addOutputData(baseAttributes[i]);
+                    incomingMetaStreamEvent.addOutputDataIfNotExist(baseAttributes[i]);
                     incomingExpressionExecutors.add(ExpressionParser.parseExpression(baseAttributeInitialValues[i],
                             incomingMetaStreamEvent, 0, tableMap, incomingVariableExpressionExecutors,
                             siddhiAppContext, false, 0, aggregatorName));
@@ -384,15 +384,15 @@ public class AggregationParser {
                 incomingMetaStreamEvent);
         ExpressionExecutor timestampExecutor = timeStampTimeZoneExecutors[0];
         ExpressionExecutor timeZoneExecutor = timeStampTimeZoneExecutors[1];
-        incomingMetaStreamEvent.addOutputData(new Attribute("_TIMESTAMP", Attribute.Type.LONG));
+        incomingMetaStreamEvent.addOutputDataIfNotExist(new Attribute("_TIMESTAMP", Attribute.Type.LONG));
         incomingExpressionExecutors.add(timestampExecutor);
 
-        incomingMetaStreamEvent.addOutputData(new Attribute("_TIMEZONE", Attribute.Type.STRING));
+        incomingMetaStreamEvent.addOutputDataIfNotExist(new Attribute("_TIMEZONE", Attribute.Type.STRING));
         incomingExpressionExecutors.add(timeZoneExecutor);
 
         AbstractDefinition incomingLastInputStreamDefinition = incomingMetaStreamEvent.getLastInputDefinition();
         for (Variable groupByVariable : groupByVariableList) {
-            incomingMetaStreamEvent.addOutputData(incomingLastInputStreamDefinition.getAttributeList()
+            incomingMetaStreamEvent.addOutputDataIfNotExist(incomingLastInputStreamDefinition.getAttributeList()
                     .get(incomingLastInputStreamDefinition.getAttributePosition(
                             groupByVariable.getAttributeName())));
             incomingExpressionExecutors.add(ExpressionParser.parseExpression(groupByVariable,
@@ -419,7 +419,7 @@ public class AggregationParser {
                                 incomingMetaStreamEvent, 0, tableMap, incomingVariableExpressionExecutors,
                                 siddhiAppContext, false, 0, aggregatorName);
                         incomingExpressionExecutors.add(expressionExecutor);
-                        incomingMetaStreamEvent.addOutputData(
+                        incomingMetaStreamEvent.addOutputDataIfNotExist(
                                 new Attribute(outputAttribute.getRename(), expressionExecutor.getReturnType()));
                         aggregationDefinition.getAttributeList().add(
                                 new Attribute(outputAttribute.getRename(), expressionExecutor.getReturnType()));
@@ -463,7 +463,7 @@ public class AggregationParser {
                             incomingMetaStreamEvent, 0, tableMap, incomingVariableExpressionExecutors,
                             siddhiAppContext, false, 0, aggregatorName);
                     incomingExpressionExecutors.add(expressionExecutor);
-                    incomingMetaStreamEvent.addOutputData(
+                    incomingMetaStreamEvent.addOutputDataIfNotExist(
                             new Attribute(outputAttribute.getRename(), expressionExecutor.getReturnType()));
                     aggregationDefinition.getAttributeList().add(
                             new Attribute(outputAttribute.getRename(), expressionExecutor.getReturnType()));

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/ExpressionParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/ExpressionParser.java
@@ -1358,7 +1358,7 @@ public class ExpressionParser {
                             .getLastInputDefinition()
                             .getAttributePosition(variableExpressionExecutor.getAttribute().getName());
                     for (Attribute attribute : metaStreamEvent.getLastInputDefinition().getAttributeList()) {
-                        metaStreamEvent.addOutputData(new Attribute(attribute.getName(), attribute.getType()));
+                        metaStreamEvent.addOutputDataIfNotExist(new Attribute(attribute.getName(), attribute.getType()));
                     }
                 }
                 metaStreamEvent.addData(new Attribute(attributeName, type));

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/MatcherParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/MatcherParser.java
@@ -42,7 +42,7 @@ public class MatcherParser {
         tableStreamEvent.setEventType(MetaStreamEvent.EventType.TABLE);
         tableStreamEvent.addInputDefinition(candsidateDefinition);
         for (Attribute attribute : candsidateDefinition.getAttributeList()) {
-            tableStreamEvent.addOutputData(attribute);
+            tableStreamEvent.addOutputDataIfNotExist(attribute);
         }
 
         MetaStateEvent metaStateEvent = null;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/OutputParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/OutputParser.java
@@ -100,7 +100,7 @@ public class OutputParser {
             tableMetaStreamEvent.setEventType(MetaStreamEvent.EventType.TABLE);
             TableDefinition matchingTableDefinition = TableDefinition.id("");
             for (Attribute attribute : outputStreamDefinition.getAttributeList()) {
-                tableMetaStreamEvent.addOutputData(attribute);
+                tableMetaStreamEvent.addOutputDataIfNotExist(attribute);
                 matchingTableDefinition.attribute(attribute.getName(), attribute.getType());
             }
             matchingTableDefinition.setQueryContextStartIndex(outStream.getQueryContextStartIndex());

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/PartitionParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/PartitionParser.java
@@ -92,7 +92,7 @@ public class PartitionParser {
                 AbstractDefinition definition = metaStreamEvent.getLastInputDefinition();
                 MetaStreamEvent newMetaStreamEvent = new MetaStreamEvent();
                 for (Attribute attribute : definition.getAttributeList()) {
-                    newMetaStreamEvent.addOutputData(attribute);
+                    newMetaStreamEvent.addOutputDataIfNotExist(attribute);
                 }
                 newMetaStreamEvent.addInputDefinition(definition);
                 newMetaStreamEvent.setEventType(metaStreamEvent.getEventType());
@@ -103,7 +103,7 @@ public class PartitionParser {
             AbstractDefinition definition = ((MetaStreamEvent) stateEvent).getLastInputDefinition();
             MetaStreamEvent newMetaStreamEvent = new MetaStreamEvent();
             for (Attribute attribute : definition.getAttributeList()) {
-                newMetaStreamEvent.addOutputData(attribute);
+                newMetaStreamEvent.addOutputDataIfNotExist(attribute);
             }
             newMetaStreamEvent.addInputDefinition(definition);
             newMetaStreamEvent.setEventType(((MetaStreamEvent) stateEvent).getEventType());

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -163,7 +163,7 @@ public class DefinitionParserHelper {
             MetaStreamEvent tableMetaStreamEvent = new MetaStreamEvent();
             tableMetaStreamEvent.addInputDefinition(tableDefinition);
             for (Attribute attribute : tableDefinition.getAttributeList()) {
-                tableMetaStreamEvent.addOutputData(attribute);
+                tableMetaStreamEvent.addOutputDataIfNotExist(attribute);
             }
 
             StreamEventPool tableStreamEventPool = new StreamEventPool(tableMetaStreamEvent, 10);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
@@ -70,7 +70,7 @@ public class QueryParserHelper {
             for (MetaStateEventAttribute attribute : metaStateEvent.getOutputDataAttributes()) {
                 if (attribute != null) {
                     metaStateEvent.getMetaStreamEvent(attribute.getPosition()[STREAM_EVENT_CHAIN_INDEX])
-                            .addOutputData(attribute.getAttribute());
+                            .addOutputDataIfNotExist(attribute.getAttribute());
                 }
             }
             for (MetaStreamEvent metaStreamEvent : metaStateEvent.getMetaStreamEvents()) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
@@ -156,7 +156,7 @@ public class Window implements FindableProcessor, Snapshotable, MemoryCalculable
         metaStreamEvent.setEventType(MetaStreamEvent.EventType.WINDOW);
         metaStreamEvent.initializeAfterWindowData();
         for (Attribute attribute : windowDefinition.getAttributeList()) {
-            metaStreamEvent.addOutputData(attribute);
+            metaStreamEvent.addOutputDataIfNotExist(attribute);
         }
 
         this.streamEventPool = new StreamEventPool(metaStreamEvent, 5);

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/event/EventTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/event/EventTestCase.java
@@ -141,8 +141,8 @@ public class EventTestCase {
         Attribute symbol = new Attribute("symbol", Attribute.Type.STRING);
 
         MetaStreamEvent metaStreamEvent = new MetaStreamEvent();
-        metaStreamEvent.addOutputData(symbol);
-        metaStreamEvent.addOutputData(price);
+        metaStreamEvent.addOutputDataIfNotExist(symbol);
+        metaStreamEvent.addOutputDataIfNotExist(price);
 
         StreamDefinition streamDefinition = StreamDefinition.id("cseEventStream").attribute("symbol", Attribute.Type
                 .STRING).attribute("price", Attribute.Type.DOUBLE).attribute("volume", Attribute.Type.INT);
@@ -173,8 +173,8 @@ public class EventTestCase {
         metaStreamEvent.addData(volume);
         metaStreamEvent.initializeAfterWindowData();
         metaStreamEvent.addData(price);
-        metaStreamEvent.addOutputData(symbol);
-        metaStreamEvent.addOutputData(null);        //complex attribute
+        metaStreamEvent.addOutputDataIfNotExist(symbol);
+        metaStreamEvent.addOutputDataIfNotExist(null);        //complex attribute
 
         StreamDefinition streamDefinition = StreamDefinition.id("cseEventStream").attribute("symbol", Attribute.Type
                 .STRING).attribute("price", Attribute.Type.DOUBLE).attribute("volume", Attribute.Type.INT);
@@ -322,8 +322,8 @@ public class EventTestCase {
         metaStreamEvent.addData(symbol);
         metaStreamEvent.initializeAfterWindowData();
         metaStreamEvent.addData(price);
-        metaStreamEvent.addOutputData(symbol);
-        metaStreamEvent.addOutputData(null);
+        metaStreamEvent.addOutputDataIfNotExist(symbol);
+        metaStreamEvent.addOutputDataIfNotExist(null);
         MetaStateEvent metaStateEvent = new MetaStateEvent(1);
         metaStateEvent.addEvent(metaStreamEvent);
 


### PR DESCRIPTION

## Purpose
> Fixing the MetaEvent Optimization method doesn't properly optimize output data

## Approach
> by stoping adding duplicate values
