### PR TITLE
Bug fix. Appruntime shutdown not working when InMemoryTable used with HA

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -45,6 +45,7 @@ import org.wso2.siddhi.core.stream.output.sink.Sink;
 import org.wso2.siddhi.core.stream.output.sink.SinkCallback;
 import org.wso2.siddhi.core.stream.output.sink.SinkHandlerManager;
 import org.wso2.siddhi.core.table.Table;
+import org.wso2.siddhi.core.table.record.RecordTableHandler;
 import org.wso2.siddhi.core.table.record.RecordTableHandlerManager;
 import org.wso2.siddhi.core.util.ExceptionUtil;
 import org.wso2.siddhi.core.util.SiddhiConstants;
@@ -352,7 +353,11 @@ public class SiddhiAppRuntime {
             RecordTableHandlerManager recordTableHandlerManager = siddhiAppContext.getSiddhiContext().
                     getRecordTableHandlerManager();
             if (recordTableHandlerManager != null) {
-                String elementId = table.getHandler().getElementId();
+                String elementId = null;
+                RecordTableHandler recordTableHandler = table.getHandler();
+                if (recordTableHandler != null) {
+                    elementId = recordTableHandler.getElementId();
+                }
                 if (elementId != null) {
                     recordTableHandlerManager.unregisterRecordTableHandler(elementId);
                 }


### PR DESCRIPTION
## Purpose
> Check for null when unregistering recordTableHandler becuase InMemoryTables handler is null

## Approach
> Check if handler is null before unregistering

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes