### PR TITLE
Removing annotations array list from annotation definition class and overloading tostring method in definitions

### DIFF
--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AbstractDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AbstractDefinition.java
@@ -106,13 +106,17 @@ public abstract class AbstractDefinition implements SiddhiElement {
 
     @Override
     public String toString() {
+       return toString("stream");
+    }
+
+     protected String toString(String type) {
         StringBuilder definitionBuilder = new StringBuilder();
         if (annotations != null && annotations.size() > 0) {
             for (Annotation annotation : annotations) {
                 definitionBuilder.append(annotation.toString());
             }
         }
-        definitionBuilder.append("define stream ").append(id).append(" (");
+        definitionBuilder.append("define " ).append(type).append(" ").append(id).append(" (");
         boolean isFirst = true;
         for (Attribute attribute : attributeList) {
             if (!isFirst) {
@@ -126,7 +130,6 @@ public abstract class AbstractDefinition implements SiddhiElement {
         definitionBuilder.append(")");
         return definitionBuilder.toString();
     }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AbstractDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AbstractDefinition.java
@@ -116,7 +116,7 @@ public abstract class AbstractDefinition implements SiddhiElement {
                 definitionBuilder.append(annotation.toString());
             }
         }
-        definitionBuilder.append("define " ).append(type).append(" ").append(id).append(" (");
+        definitionBuilder.append("define ").append(type).append(" ").append(id).append(" (");
         boolean isFirst = true;
         for (Attribute attribute : attributeList) {
             if (!isFirst) {

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AggregationDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AggregationDefinition.java
@@ -132,4 +132,9 @@ public class AggregationDefinition extends AbstractDefinition {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return super.toString("aggregation");
+    }
+
 }

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AggregationDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/AggregationDefinition.java
@@ -24,7 +24,6 @@ import org.wso2.siddhi.query.api.execution.query.selection.BasicSelector;
 import org.wso2.siddhi.query.api.execution.query.selection.Selector;
 import org.wso2.siddhi.query.api.expression.Variable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,7 +36,6 @@ public class AggregationDefinition extends AbstractDefinition {
     private Selector selector = null;
     private Variable aggregateAttribute = null;
     private TimePeriod timePeriod = null;
-    private List<Annotation> annotations = new ArrayList<>();
 
     protected AggregationDefinition(String id) {
         super(id);

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/TableDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/TableDefinition.java
@@ -44,4 +44,9 @@ public class TableDefinition extends AbstractDefinition {
         return this;
     }
 
+    @Override
+    public String toString() {
+        return super.toString("table");
+    }
+
 }

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/WindowDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/definition/WindowDefinition.java
@@ -99,6 +99,6 @@ public class WindowDefinition extends StreamDefinition {
 
     @Override
     public String toString() {
-        return super.toString() + " " + window.toString();
+        return super.toString("window") + " " + window.toString();
     }
 }


### PR DESCRIPTION
## Purpose
Removing annotations array list from annotation definition class

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes