### PR TITLE
Improvements to Incremental Aggregation

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -106,6 +106,8 @@ public class RecreateInMemoryData {
             events = storeQueryRuntime.execute();
 
             if (events != null) {
+                long referenceToNextLatestEvent = (Long) events[events.length - 1].getData(0);
+                String timeZoneOfNextLatestEvent = events[events.length - 1].getData(1).toString();
                 if (latestEventTimestamp != null) {
                     List<Event> eventsNewerThanLatestEventOfRecreateForDuration = new ArrayList<>();
                     for (Event event : events) {
@@ -122,7 +124,7 @@ public class RecreateInMemoryData {
                             new Event[eventsNewerThanLatestEventOfRecreateForDuration.size()]);
                 }
 
-                latestEventTimestamp = (Long) events[events.length - 1].getData(0);
+                latestEventTimestamp = referenceToNextLatestEvent;
 
                 ComplexEventChunk<StreamEvent> complexEventChunk = new ComplexEventChunk<>(false);
                 for (Event event : events) {
@@ -136,7 +138,7 @@ public class RecreateInMemoryData {
                     TimePeriod.Duration rootDuration = incrementalDurations.get(0);
                     IncrementalExecutor rootIncrementalExecutor = incrementalExecutorMap.get(rootDuration);
                     long emitTimeOfLatestEventInTable = IncrementalTimeConverterUtil.getNextEmitTime(
-                            latestEventTimestamp, rootDuration, events[events.length - 1].getData(1).toString());
+                            latestEventTimestamp, rootDuration, timeZoneOfNextLatestEvent);
 
                     rootIncrementalExecutor.setValuesForInMemoryRecreateFromTable(true, emitTimeOfLatestEventInTable);
 

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/AggregationTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/AggregationTestCase.java
@@ -836,10 +836,10 @@ public class AggregationTestCase {
         Thread.sleep(2000);
 
         LocalDate currentDate = LocalDate.now();
-        int year = currentDate.getYear();
-        Integer month = currentDate.getMonth().getValue();
-        if (month.toString().length() == 1) {
-            month = Integer.parseInt("0".concat(month.toString()));
+        String year = String.valueOf(currentDate.getYear());
+        String month = String.valueOf(currentDate.getMonth().getValue());
+        if (month.length() == 1) {
+            month = "0".concat(month);
         }
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
@@ -2460,10 +2460,10 @@ public class AggregationTestCase {
         siddhiAppRuntime.start();
 
         LocalDate currentDate = LocalDate.now();
-        int year = currentDate.getYear();
-        Integer month = currentDate.getMonth().getValue();
-        if (month.toString().length() == 1) {
-            month = Integer.parseInt("0".concat(month.toString()));
+        String year = String.valueOf(currentDate.getYear());
+        String month = String.valueOf(currentDate.getMonth().getValue());
+        if (month.length() == 1) {
+            month = "0".concat(month);
         }
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +


### PR DESCRIPTION
1) Correct recreate in-memory data logic by keeping reference to next latest event prior to filtering out events. Otherwise, issues may occur if number of events equals 0, when filtered based on latest event.
2) Improve tests

