### PR TITLE
Fix partition snapshot and restore

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/partition/PartitionRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/partition/PartitionRuntime.java
@@ -314,7 +314,8 @@ public class PartitionRuntime implements Snapshotable {
     @Override
     public Map<String, Object> currentState() {
         Map<String, Object> state = new HashMap<>();
-        state.put("PartitionKeys", partitionInstanceRuntimeMap.keySet());
+        List<String> partitionKeys = new ArrayList<>(partitionInstanceRuntimeMap.keySet());
+        state.put("PartitionKeys", partitionKeys);
         return state;
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
@@ -255,6 +255,7 @@ public class SiddhiAppParser {
                             (Partition) executionElement, siddhiAppContext,
                             siddhiAppRuntimeBuilder.getStreamDefinitionMap(), queryIndex);
                     siddhiAppRuntimeBuilder.addPartition(partitionRuntime);
+                    siddhiAppContext.getSnapshotService().addSnapshotable("partition", partitionRuntime);
                     queryIndex += ((Partition) executionElement).getQueryList().size();
                 } catch (Throwable t) {
                     ExceptionUtil.populateQueryContext(t, (Partition) executionElement, siddhiAppContext);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
@@ -130,7 +130,23 @@ public class SnapshotService {
         List<Snapshotable> snapshotableList;
         try {
             threadBarrier.lock();
+            List<Snapshotable> partitionSnapshotables = snapshotableMap.get("partition");
+            try {
+                if (partitionSnapshotables != null) {
+                    for (Snapshotable snapshotable : partitionSnapshotables) {
+                        snapshotable.restoreState(snapshots.get(snapshotable.getElementId()));
+                    }
+                }
+            } catch (Throwable t) {
+                throw new CannotRestoreSiddhiAppStateException("Restoring of Siddhi app " + siddhiAppContext.
+                        getName() + " not completed properly because content of Siddhi app has changed since " +
+                        "last state persistence. Clean persistence store for a fresh deployment.", t);
+            }
+
             for (Map.Entry<String, List<Snapshotable>> entry : snapshotableMap.entrySet()) {
+                if (entry.getKey().equals("partition")) {
+                    continue;
+                }
                 snapshotableList = entry.getValue();
                 try {
                     for (Snapshotable snapshotable : snapshotableList) {
@@ -146,5 +162,4 @@ public class SnapshotService {
             threadBarrier.unlock();
         }
     }
-
 }


### PR DESCRIPTION
## Purpose
> Elements of partitions are created dynamically hence restoring of state is not functioning properly

## Goals
> Persist partition keys in snapshot and restore the partition runtimes first so that all elements of partitions are created before restoring all other elements 

## Approach
> Register all partition runtimes to snapshot service under common name - "partition" so that keys of all partitions are saved in the snapshot
> When restoring, restore the partition runtimes first so that the according to the partition keys relevant elements are created.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes