### PR TITLE
Change expectedException in DefineStreamTestCase

### DIFF
--- a/modules/siddhi-query-compiler/src/test/java/org/wso2/siddhi/query/test/DefineStreamTestCase.java
+++ b/modules/siddhi-query-compiler/src/test/java/org/wso2/siddhi/query/test/DefineStreamTestCase.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import org.wso2.siddhi.query.api.annotation.Annotation;
 import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
-import org.wso2.siddhi.query.api.exception.DuplicateAttributeException;
 import org.wso2.siddhi.query.compiler.SiddhiCompiler;
 import org.wso2.siddhi.query.compiler.exception.SiddhiParserException;
 
@@ -67,7 +66,7 @@ public class DefineStreamTestCase {
         AssertJUnit.assertEquals(api, streamDefinition);
     }
 
-    @Test(expectedExceptions = DuplicateAttributeException.class)
+    @Test(expectedExceptions = SiddhiParserException.class)
     public void testCreatingStreamWithDuplicateAttribute() {
         StreamDefinition streamDefinition = SiddhiCompiler.parseStreamDefinition("define stream StockStream ( symbol " +
                 "string, symbol int, volume float );");


### PR DESCRIPTION
## Purpose
> Change test case to expect SiddhiParserException instead of DuplicateAttributeException

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Change expectedException in test case

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A