### PR TITLE
Fix test time test cases for different time zones

### DIFF
--- a/modules/siddhi-extensions/time/src/test/java/org/wso2/siddhi/extension/time/ExtractAttributesFunctionExtensionTestCase.java
+++ b/modules/siddhi-extensions/time/src/test/java/org/wso2/siddhi/extension/time/ExtractAttributesFunctionExtensionTestCase.java
@@ -98,20 +98,20 @@ public class ExtractAttributesFunctionExtensionTestCase {
         Calendar calendarEN = Calendar.getInstance(LocaleUtils.toLocale("en_US"));
         Calendar calendarFR = Calendar.getInstance(LocaleUtils.toLocale("fr_FR"));
         FastDateFormat userSpecificFormat;
-        userSpecificFormat = FastDateFormat.getInstance("yyyy-MM-dd");
-        Date userSpecifiedDate = userSpecificFormat.parse("2017-10-8");
+        userSpecificFormat = FastDateFormat.getInstance("yyyy-MM-dd hh:mm:ss");
+        Date userSpecifiedDate = userSpecificFormat.parse("2014-3-11 02:23:44");
         calendarEN.setTime(userSpecifiedDate);
         calendarFR.setTime(userSpecifiedDate);
-        final Integer valueEN =  calendarEN.get(Calendar.WEEK_OF_YEAR);
-        final Integer valueFR =  calendarFR.get(Calendar.WEEK_OF_YEAR);
+        final int valueEN = calendarEN.get(Calendar.WEEK_OF_YEAR);
+        final int valueENHour = calendarEN.get(Calendar.HOUR_OF_DAY);
 
         String inStreamDefinition = "" +
                 "define stream inputStream (symbol string,dateValue string,dateFormat string,timestampInMilliseconds " +
                 "long);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
-                "select symbol , time:extract('YEAR',dateValue,dateFormat) as YEAR,time:extract('MONTH',dateValue," +
-                "dateFormat) as MONTH,time:extract(timestampInMilliseconds,'HOUR') as HOUR " +
+                "select symbol , time:extract('WEEK',dateValue,dateFormat,'en_US') as YEAR,time:extract('MONTH',dateValue," +
+                "dateFormat,'en_US') as MONTH,time:extract('HOUR',dateValue,dateFormat,'en_US') as HOUR " +
                 "insert into outputStream;");
         ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(inStreamDefinition +
                 query);
@@ -122,26 +122,15 @@ public class ExtractAttributesFunctionExtensionTestCase {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
                 eventArrived = true;
                 for (Event event : inEvents) {
-                    count++;
-                    if (count == 1) {
-                        Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals(null, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
-                    }
-                    if (count == 2) {
-                        Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals(null, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
-                    }
+                    Assert.assertEquals(valueEN, event.getData(1));
+                    Assert.assertEquals(valueENHour, event.getData(3));
                 }
             }
         });
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
-        inputHandler.send(new Object[]{"IBM", "2014:3-11 02:23:44", "yyyy-MM-dd hh:mm:ss", 1394484824000L});
-        inputHandler.send(new Object[]{"IBM", "2015:3-11 02:23:44", "yyyy-MM-dd hh:mm:ss", 1394484824000L});
+        inputHandler.send(new Object[]{"IBM", "2014-3-11 02:23:44", "yyyy-MM-dd hh:mm:ss", 1394484824000L});
         Thread.sleep(100);
-        Assert.assertEquals(2, count);
         Assert.assertTrue(eventArrived);
         executionPlanRuntime.shutdown();
     }
@@ -219,13 +208,17 @@ public class ExtractAttributesFunctionExtensionTestCase {
         log.info("ExtractAttributesFunctionExtensionSecondArgumentNullTestCase");
         SiddhiManager siddhiManager = new SiddhiManager();
 
+        Calendar calendarEN = Calendar.getInstance(LocaleUtils.toLocale("en_US"));
+        calendarEN.setTimeInMillis(1394484824000L);
+        final int valueEN = calendarEN.get(Calendar.HOUR_OF_DAY);
+
         String inStreamDefinition = "" +
                 "define stream inputStream (symbol string,dateValue string,dateFormat string,timestampInMilliseconds" +
                 " long);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
                 "select symbol , time:extract('YEAR',dateValue,dateFormat) as YEAR,time:extract('MONTH',dateValue," +
-                "dateFormat) as MONTH,time:extract(timestampInMilliseconds,'HOUR') as HOUR " +
+                "dateFormat) as MONTH,time:extract(timestampInMilliseconds,'HOUR','en_US') as HOUR " +
                 "insert into outputStream;");
         ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(inStreamDefinition +
                 query);
@@ -236,26 +229,16 @@ public class ExtractAttributesFunctionExtensionTestCase {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
                 eventArrived = true;
                 for (Event event : inEvents) {
-                    count++;
-                    if (count == 1) {
-                        Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals(null, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
-                    }
-                    if (count == 2) {
-                        Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals(null, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
-                    }
+                    Assert.assertEquals(null, event.getData(1));
+                    Assert.assertEquals(null, event.getData(2));
+                    Assert.assertEquals(valueEN, event.getData(3));
                 }
             }
         });
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
         inputHandler.send(new Object[]{"IBM", null, "yyyy-MM-dd hh:mm:ss", 1394484824000L});
-        inputHandler.send(new Object[]{"IBM", null, "ss", 1394484824000L});
         Thread.sleep(100);
-        Assert.assertEquals(2, count);
         Assert.assertTrue(eventArrived);
         executionPlanRuntime.shutdown();
     }
@@ -264,6 +247,9 @@ public class ExtractAttributesFunctionExtensionTestCase {
 
         log.info("ExtractAttributesFunctionExtensionThirdArgumentNullTestCase");
         SiddhiManager siddhiManager = new SiddhiManager();
+        Calendar calendarEN = Calendar.getInstance(LocaleUtils.toLocale("en_US"));
+        calendarEN.setTimeInMillis(1394484824000L);
+        final int valueEN = calendarEN.get(Calendar.HOUR_OF_DAY);
 
         String inStreamDefinition = "" +
                 "define stream inputStream (symbol string,dateValue string,dateFormat string,timestampInMilliseconds" +
@@ -271,7 +257,7 @@ public class ExtractAttributesFunctionExtensionTestCase {
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
                 "select symbol , time:extract('YEAR',dateValue,dateFormat) as YEAR,time:extract('MONTH',dateValue," +
-                "dateFormat) as MONTH,time:extract(timestampInMilliseconds,'HOUR') as HOUR " +
+                "dateFormat) as MONTH,time:extract(timestampInMilliseconds,'HOUR','en_US') as HOUR " +
                 "insert into outputStream;");
         ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(inStreamDefinition +
                 query);
@@ -282,26 +268,16 @@ public class ExtractAttributesFunctionExtensionTestCase {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
                 eventArrived = true;
                 for (Event event : inEvents) {
-                    count++;
-                    if (count == 1) {
-                        Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals(null, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
-                    }
-                    if (count == 2) {
-                        Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals(null, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
-                    }
+                    Assert.assertEquals(null, event.getData(1));
+                    Assert.assertEquals(null, event.getData(2));
+                    Assert.assertEquals(valueEN, event.getData(3));
                 }
             }
         });
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
         inputHandler.send(new Object[]{"IBM", "2014:3-11 02:23:44", null, 1394484824000L});
-        inputHandler.send(new Object[]{"IBM", "2012:3-11 02:23:44", null, 1394484824000L});
         Thread.sleep(100);
-        Assert.assertEquals(2, count);
         Assert.assertTrue(eventArrived);
         executionPlanRuntime.shutdown();
     }
@@ -362,20 +338,31 @@ public class ExtractAttributesFunctionExtensionTestCase {
         siddhiManager.createExecutionPlanRuntime(inStreamDefinition + query);
     }
 
-    public void extractAttributesFunctionExtension13() throws InterruptedException {
+    @Test
+    public void extractAttributesFunctionExtension13() throws InterruptedException, ParseException {
 
         log.info("ExtractAttributesFunctionExtensionProcessedCalenderTestCase");
         SiddhiManager siddhiManager = new SiddhiManager();
+        Calendar calendarEN = Calendar.getInstance(LocaleUtils.toLocale("en_US"));
+        calendarEN.setTimeInMillis(1394484824000L);
+        final int valueENHour = calendarEN.get(Calendar.HOUR_OF_DAY);
+        FastDateFormat userSpecificFormat;
+        userSpecificFormat = FastDateFormat.getInstance("yyyy-MM-dd hh:mm:ss");
+        Date userSpecifiedDate = userSpecificFormat.parse("2014-3-11 02:23:44");
+        calendarEN.setTime(userSpecifiedDate);
+        final int valueENSec = calendarEN.get(Calendar.SECOND);
+        final int valueENMon = calendarEN.get(Calendar.MONTH) + 1;
+
 
         String inStreamDefinition = "" +
                 "define stream inputStream (symbol string,dateValue string,dateFormat string,timestampInMilliseconds" +
                 " long);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
-                "select symbol , time:extract('SECOND',dateValue,dateFormat) as SECOND,time:extract('MONTH'," +
-                "dateValue,dateFormat) as MONTH,time:extract(timestampInMilliseconds,'HOUR') as HOUR," +
-                "time:extract(timestampInMilliseconds,'MINUTE') as MINUTE," +
-                "time:extract(timestampInMilliseconds,'HOUR_OF_DAY') as HOUR_OF_DAY " +
+                "select symbol , time:extract('SECOND',dateValue,dateFormat,'en_US') as SECOND,time:extract('MONTH'," +
+                "dateValue,dateFormat,'en_US') as MONTH,time:extract(timestampInMilliseconds,'HOUR','en_US') as HOUR," +
+                "time:extract(timestampInMilliseconds,'MINUTE','en_US') as MINUTE," +
+                "time:extract(timestampInMilliseconds,'HOUR_OF_DAY','en_US') as HOUR_OF_DAY " +
                 "insert into outputStream;");
         ExecutionPlanRuntime executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(inStreamDefinition +
                 query);
@@ -388,14 +375,14 @@ public class ExtractAttributesFunctionExtensionTestCase {
                 for (Event event : inEvents) {
                     count++;
                     if (count == 1) {
-                        Assert.assertEquals(44, event.getData(1));
-                        Assert.assertEquals(3, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
+                        Assert.assertEquals(valueENSec, event.getData(1));
+                        Assert.assertEquals(valueENMon, event.getData(2));
+                        Assert.assertEquals(valueENHour, event.getData(3));
                     }
                     if (count == 2) {
-                        Assert.assertEquals(44, event.getData(1));
-                        Assert.assertEquals(3, event.getData(2));
-                        Assert.assertEquals("2", event.getData(3).toString());
+                        Assert.assertEquals(valueENSec, event.getData(1));
+                        Assert.assertEquals(valueENMon, event.getData(2));
+                        Assert.assertEquals(valueENHour, event.getData(3));
                     }
                 }
             }

--- a/modules/siddhi-extensions/time/src/test/java/org/wso2/siddhi/extension/time/TimestampInMillisecondsFunctionExtensionTestCase.java
+++ b/modules/siddhi-extensions/time/src/test/java/org/wso2/siddhi/extension/time/TimestampInMillisecondsFunctionExtensionTestCase.java
@@ -19,6 +19,8 @@
 package org.wso2.siddhi.extension.time;
 
 import junit.framework.Assert;
+import org.apache.commons.lang3.LocaleUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +31,10 @@ import org.wso2.siddhi.core.query.output.callback.QueryCallback;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.util.EventPrinter;
 import org.wso2.siddhi.query.api.exception.ExecutionPlanValidationException;
+
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
 
 public class TimestampInMillisecondsFunctionExtensionTestCase {
 
@@ -318,10 +324,17 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
         siddhiManager.createExecutionPlanRuntime(inStreamDefinition + query);
     }
 
-    public void timestampInMillisecondsWithAllArgumentsFunctionExtension8() throws InterruptedException {
+    @Test
+    public void timestampInMillisecondsWithAllArgumentsFunctionExtension8() throws InterruptedException, ParseException {
 
         log.info("TimestampInMillisecondsWithAllArgumentsFunctionExtensionFirstArgumentNullTestCase");
         SiddhiManager siddhiManager = new SiddhiManager();
+        Calendar calendarEN = Calendar.getInstance(LocaleUtils.toLocale("en_US"));
+        FastDateFormat userSpecificFormat;
+        userSpecificFormat = FastDateFormat.getInstance("yyyy-MM-dd hh:mm:ss");
+        Date userSpecifiedDate = userSpecificFormat.parse("2007-11-30 10:30:19.000");
+        calendarEN.setTime(userSpecifiedDate);
+        final long valueEN = calendarEN.getTimeInMillis();
 
         String inStreamDefinition = "" +
                 "define stream inputStream (symbol string, price string, volume long);";
@@ -341,7 +354,7 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
                     count++;
                     if (count == 1) {
                         Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals("1196398819000", event.getData(2).toString());
+                        Assert.assertEquals(valueEN, event.getData(2));
                         eventArrived = true;
                     }
                 }
@@ -356,10 +369,17 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
         executionPlanRuntime.shutdown();
     }
 
-    public void timestampInMillisecondsWithAllArgumentsFunctionExtension9() throws InterruptedException {
+    @Test
+    public void timestampInMillisecondsWithAllArgumentsFunctionExtension9() throws InterruptedException, ParseException {
 
         log.info("TimestampInMillisecondsWithAllArgumentsFunctionExtensionSecondArgumentNullTestCase");
         SiddhiManager siddhiManager = new SiddhiManager();
+        Calendar calendarEN = Calendar.getInstance(LocaleUtils.toLocale("en_US"));
+        FastDateFormat userSpecificFormat;
+        userSpecificFormat = FastDateFormat.getInstance("yyyy-MM-dd hh:mm:ss");
+        Date userSpecifiedDate = userSpecificFormat.parse("2007-11-30 10:30:19.000");
+        calendarEN.setTime(userSpecifiedDate);
+        final long valueEN = calendarEN.getTimeInMillis();
 
         String inStreamDefinition = "" +
                 "define stream inputStream (symbol string, price long, volume string);";
@@ -379,7 +399,7 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
                     count++;
                     if (count == 1) {
                         Assert.assertEquals(null, event.getData(1));
-                        Assert.assertEquals("1196398819000", event.getData(2).toString());
+                        Assert.assertEquals(valueEN, event.getData(2));
                         eventArrived = true;
                     }
                 }


### PR DESCRIPTION
## Purpose
> This will fix the test cases issue in the time component of the siddhi extensions.

## Goals
> This will fix the test cases issue in the time component of the siddhi extensions.

## Approach
> Remove the hardcoded values in the test cases and use Java Util calender to get the time according to the time-zone

## User stories
> NA

## Release note
> NA

## Documentation
> NA

## Training
> NA

## Certification
> NA

## Marketing
> NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> NA

## Related PRs
> NA

## Migrations (if applicable)
> NA

## Test environment
java version "1.7.0_80"
Java(TM) SE Runtime Environment (build 1.7.0_80-b15)
Java HotSpot(TM) 64-Bit Server VM (build 24.80-b11, mixed mode)

 
## Learning
> NA