### PR TITLE
Fix a bug

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/record/AbstractRecordTable.java
@@ -20,6 +20,7 @@ package org.wso2.siddhi.core.table.record;
 
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.event.ComplexEvent;
 import org.wso2.siddhi.core.event.ComplexEventChunk;
 import org.wso2.siddhi.core.event.state.StateEvent;
 import org.wso2.siddhi.core.event.stream.StreamEvent;
@@ -88,7 +89,7 @@ public abstract class AbstractRecordTable extends Table {
         addingEventChunk.reset();
         long timestamp = 0L;
         while (addingEventChunk.hasNext()) {
-            StreamEvent event = addingEventChunk.next();
+            ComplexEvent event = addingEventChunk.next();
             records.add(event.getOutputData());
             timestamp = event.getTimestamp();
         }


### PR DESCRIPTION

## Purpose
> When someone use group by with "window.timeBatch" tag  and put the result to the table. It will shown a stacktrace in the console "java.lang.ClassCastException: org.wso2.siddhi.event.GroupedComplexEvent cannot be cast to org.wso2.siddhi.event.stream.StreamEvent" .
As the code shows.In line :92 we need not declare a implement class type .It's just use their interface which is implemented by them
More detail : issue -> https://github.com/wso2/siddhi/issues/800

## Goals
> fix the problem When use group by with window.timeBatch ,data can't insert into table.

## Approach
> https://github.com/wso2/siddhi/blob/e32fa0d7ca0a6650dbd0dad377da1685601812c6/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/record/AbstractRecordTable.java#L91
use the interface to declare variable because both StreamEvent and GroupedComplexEvent implement ComplexEvent interface.
`ComplexEvent event = addingEventChunk.next();`

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

