### PR TITLE
Add transport channel creation property to SiddhiAppContext

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/SiddhiAppContext.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/SiddhiAppContext.java
@@ -63,6 +63,7 @@ public class SiddhiAppContext {
     private int bufferSize;
     private String siddhiAppString;
     private List<String> includedMetrics;
+    private boolean transportChannelCreationEnabled;
 
     public SiddhiAppContext() {
         this.eternalReferencedHolders = Collections.synchronizedList(new LinkedList<>());
@@ -227,5 +228,13 @@ public class SiddhiAppContext {
 
     public List<String> getIncludedMetrics() {
         return includedMetrics;
+    }
+
+    public boolean isTransportChannelCreationEnabled() {
+        return transportChannelCreationEnabled;
+    }
+
+    public void setTransportChannelCreationEnabled(boolean transportChannelCreationEnabled) {
+        this.transportChannelCreationEnabled = transportChannelCreationEnabled;
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiConstants.java
@@ -107,5 +107,6 @@ public final class SiddhiConstants {
     public static final String EXTENSION_SEPARATOR = ":";
 
     public static final String KEY_DELIMITER = ":-:";
+    public static final String TRANSPORT_CHANNEL_CREATION_IDENTIFIER = "transportChannelCreationEnabled";
 
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
@@ -142,6 +142,15 @@ public class SiddhiAppParser {
                     SiddhiConstants.ANNOTATION_ELEMENT_INCLUDE, siddhiApp.getAnnotations());
             siddhiAppContext.setIncludedMetrics(generateIncludedMetrics(statStateIncludElement));
 
+            Element transportCreationEnabledElement = AnnotationHelper.getAnnotationElement(
+                    SiddhiConstants.TRANSPORT_CHANNEL_CREATION_IDENTIFIER, null, siddhiApp.getAnnotations());
+            if (transportCreationEnabledElement == null) {
+                siddhiAppContext.setTransportChannelCreationEnabled(true);
+            } else {
+                siddhiAppContext.setTransportChannelCreationEnabled(
+                        Boolean.valueOf(transportCreationEnabledElement.getValue()));
+            }
+
 
             siddhiAppContext.setThreadBarrier(new ThreadBarrier());
 


### PR DESCRIPTION
## Purpose
Provide option for users to control transport channel creation. Currently only Kafka sources will support it. 

## Approach
Siddhi App level annotation 'transportChannelCreationEnabled' is introduced. At AppParser annotation will be extracted and set to SiddhiAppContext so that it can be used across sources. Default value is true

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8
 
