### PR TITLE
Fix issue in restoring siddhi app from non existing revision

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
@@ -21,6 +21,7 @@ import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
 import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import org.wso2.siddhi.core.exception.NoPersistenceStoreException;
+import org.wso2.siddhi.core.exception.PersistenceStoreException;
 import org.wso2.siddhi.core.util.ThreadBarrier;
 import org.wso2.siddhi.core.util.persistence.IncrementalPersistenceStore;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
@@ -418,6 +419,7 @@ public class SnapshotService {
                 if (log.isDebugEnabled()) {
                     log.debug("No data found for revision: " + revision);
                 }
+                throw new PersistenceStoreException("No data found for revision: " + revision);
             }
         } else if (incrementalPersistenceStore != null) {
             if (log.isDebugEnabled()) {
@@ -477,6 +479,7 @@ public class SnapshotService {
                 if (log.isDebugEnabled()) {
                     log.debug("No data found for revision: " + revision);
                 }
+                throw new PersistenceStoreException("No data found for revision: " + revision);
             }
         } else {
             throw new NoPersistenceStoreException("No persistence store assigned for siddhi app " +


### PR DESCRIPTION
## Purpose
Fix issue in restoring siddhi app from non-existing revision. Currently, when we are trying to restore siddhiApp from a non-existing revision, it will not return any exception. 

## Goals
Fix issue in restoring siddhi app from non-existing revision.

## Approach
Throw a new exception when there is no revision related to the requested siddhi app.

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_171"
Java(TM) SE Runtime Environment (build 1.8.0_171-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.171-b11, mixed mode)
 
## Learning
NA