### PR TITLE
Changing revision separator to double-underscore.

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/IncrementalFileSystemPersistenceStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/IncrementalFileSystemPersistenceStore.java
@@ -55,7 +55,7 @@ public class IncrementalFileSystemPersistenceStore implements IncrementalPersist
             cleanOldRevisions(snapshotInfo);
             if (log.isDebugEnabled()) {
                 log.debug("Incremental persistence of '" + snapshotInfo.getSiddhiAppId() +
-                        "' with revision '" + snapshotInfo.getRevision() + "' persisted successfully.");
+                       "' with revision '" + snapshotInfo.getRevision() + "' persisted successfully.");
             }
         } catch (IOException e) {
             log.error("Cannot save the revision '" + snapshotInfo.getRevision() + "' of SiddhiApp: '" +

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/util/PersistenceConstants.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/util/PersistenceConstants.java
@@ -26,6 +26,6 @@ public class PersistenceConstants {
     public static final String STATE_PERSISTENCE_REVISIONS_TO_KEEP = "revisionsToKeep";
     public static final String STATE_PERSISTENCE_CONFIGS = "config";
     public static final String DEFAULT_FILE_PERSISTENCE_FOLDER = "siddhi-app-persistence";
-    public static final String REVISION_SEPARATOR = "_";
+    public static final String REVISION_SEPARATOR = "__";
 
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/util/PersistenceHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/util/PersistenceHelper.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Future;
 public final class PersistenceHelper {
 
     public static IncrementalSnapshotInfo convertRevision(String revision) {
-        String[] items = revision.split("_");
+        String[] items = revision.split(PersistenceConstants.REVISION_SEPARATOR);
         //Note: Here we discard the (items.length == 2) scenario which is handled by the full snapshot handling
         if (items.length == 5) {
             return new IncrementalSnapshotInfo(items[1], items[2], items[3],

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/AsyncSnapshotPersistor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/AsyncSnapshotPersistor.java
@@ -21,6 +21,7 @@ package org.wso2.siddhi.core.util.snapshot;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.exception.NoPersistenceStoreException;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
+import org.wso2.siddhi.core.util.persistence.util.PersistenceConstants;
 
 /**
  * {@link Runnable} which is responsible for persisting the snapshots that are taken
@@ -43,7 +44,7 @@ public class AsyncSnapshotPersistor implements Runnable {
         this.persistenceStore = persistenceStore;
         this.siddhiAppName = siddhiAppName;
         this.time = time;
-        this.revision = time + "_" + siddhiAppName;
+        this.revision = time + PersistenceConstants.REVISION_SEPARATOR + siddhiAppName;
     }
 
     public String getRevision() {


### PR DESCRIPTION
## Purpose
The default query IDs set by Siddhi takes the form query_1, query_2 etc. This breaks revision conversion.

