### PR TITLE
Fix NPE when window doesn't have any parameters.

### DIFF
--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/handler/Window.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/handler/Window.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 public class Window implements StreamHandler, Extension, SiddhiElement {
 
     private static final long serialVersionUID = 1L;
-    private String namespace = "";
+    private String namespace;
     private String function;
     private Expression[] parameters;
     private int[] queryContextStartIndex;

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/handler/Window.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/handler/Window.java
@@ -37,18 +37,16 @@ public class Window implements StreamHandler, Extension, SiddhiElement {
 
     public Window(String namespace, String functionName, Expression[] parameters) {
         this.function = functionName;
-        this.parameters = Arrays.copyOfRange(parameters, 0, parameters.length);
+        this.parameters = (parameters == null) ? null : Arrays.copyOfRange(parameters, 0, parameters.length);
         this.namespace = namespace;
     }
 
     public Window(String namespace, String functionName) {
-        this.function = functionName;
-        this.namespace = namespace;
+        this(namespace, functionName, null);
     }
 
     public Window(String functionName, Expression[] parameters) {
-        this.function = functionName;
-        this.parameters = Arrays.copyOfRange(parameters, 0, parameters.length);
+        this("", functionName, parameters);
     }
 
     public Window(String functionName) {
@@ -60,7 +58,7 @@ public class Window implements StreamHandler, Extension, SiddhiElement {
     }
 
     public Expression[] getParameters() {
-        return Arrays.copyOfRange(parameters, 0, parameters.length);
+        return (parameters == null) ? null : Arrays.copyOfRange(parameters, 0, parameters.length);
     }
 
     public String getNamespace() {


### PR DESCRIPTION
## Purpose
Fixes #863 

## Goals
- Adding support for windows that doesn't have any parameters.
```sql
from inputStream#window.chunk()
```

## Approach
- Add `null` check in `Window(String namespace, String functionName, Expression[] parameters)` constructor.
- Use constructor chaining.
- Add `null` guard in `getParameters` method.

## Automation tests
 - Unit tests 
   - passes all
 - Integration tests
   - passes all

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
