### PR TITLE
Fix window batch state persistence NLP issue

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/BatchWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/BatchWindowProcessor.java
@@ -142,7 +142,7 @@ public class BatchWindowProcessor extends WindowProcessor implements FindablePro
     public Map<String, Object> currentState() {
         Map<String, Object> state = new HashMap<>();
         synchronized (this) {
-            state.put("ExpiredEventQueue", expiredEventQueue.getSnapshot());
+            state.put("ExpiredEventQueue", expiredEventQueue != null ? expiredEventQueue.getSnapshot() : null);
             state.put("ResetEvent", resetEvent);
         }
         return state;


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/siddhi/issues/883

## Goals
> Fix the window batch state persistence NLP issue

## Approach
> Check the nullity of the 'expiredEventQueue' before persistence the state.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes