### PR TITLE
Update equals methods in OrderByAttribute and AggregationInputStore

### DIFF
--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/store/AggregationInputStore.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/store/AggregationInputStore.java
@@ -64,6 +64,13 @@ public class AggregationInputStore extends ConditionInputStore {
         if (within != null ? !within.equals(that.within) : that.within != null) {
             return false;
         }
+        if (onCondition != null ? !onCondition.equals(that.onCondition) :
+                that.onCondition != null) {
+            return false;
+        }
+        if (store != null ? !store.equals(that.store) : that.store != null) {
+            return false;
+        }
         return per != null ? per.equals(that.per) : that.per == null;
     }
 

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/store/AggregationInputStore.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/input/store/AggregationInputStore.java
@@ -64,8 +64,7 @@ public class AggregationInputStore extends ConditionInputStore {
         if (within != null ? !within.equals(that.within) : that.within != null) {
             return false;
         }
-        if (onCondition != null ? !onCondition.equals(that.onCondition) :
-                that.onCondition != null) {
+        if (onCondition != null ? !onCondition.equals(that.onCondition) : that.onCondition != null) {
             return false;
         }
         if (store != null ? !store.equals(that.store) : that.store != null) {

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/selection/OrderByAttribute.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/selection/OrderByAttribute.java
@@ -68,6 +68,28 @@ public class OrderByAttribute implements SiddhiElement {
         queryContextEndIndex = lineAndColumn;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof OrderByAttribute)) {
+            return false;
+        }
+        OrderByAttribute that = (OrderByAttribute) o;
+        if (order != null ? !order.equals(that.order) : that.order != null) {
+            return false;
+        }
+        return variable != null ? variable.equals(that.variable) : that.variable == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = order != null ? order.hashCode() : 0;
+        result = 31 * result + (variable != null ? variable.hashCode() : 0);
+        return result;
+    }
+
     /**
      * enum for ascending and descending
      */

--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/selection/Selector.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/execution/query/selection/Selector.java
@@ -153,6 +153,7 @@ public class Selector implements SiddhiElement {
                 "selectionList=" + selectionList +
                 ", groupByList=" + groupByList +
                 ", havingExpression=" + havingExpression +
+                ", orderByList=" + orderByList +
                 '}';
     }
 
@@ -177,8 +178,7 @@ public class Selector implements SiddhiElement {
         if (selectionList != null ? !selectionList.equals(selector.selectionList) : selector.selectionList != null) {
             return false;
         }
-
-        return true;
+        return orderByList != null ? orderByList.equals(selector.orderByList) : selector.orderByList == null;
     }
 
     @Override
@@ -186,6 +186,7 @@ public class Selector implements SiddhiElement {
         int result = selectionList != null ? selectionList.hashCode() : 0;
         result = 31 * result + (groupByList != null ? groupByList.hashCode() : 0);
         result = 31 * result + (havingExpression != null ? havingExpression.hashCode() : 0);
+        result = 31 * result + (orderByList != null ? orderByList.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
## Purpose
> Siddhi Store API fails to identify updated queries used with OrderBy and ON keywords. Identifying the updated queries.
> Fixes [#753](https://github.com/wso2/product-sp/issues/753) and [#743](https://github.com/wso2/product-sp/issues/743)

## Approach
> Override equals methods in OrderByAttribute and AggregationInputStore
