### PR TITLE
Adding latest aggregator support for Incremental Aggregations

### DIFF
--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v4.2.12
+# API Docs - v4.2.13-SNAPSHOT
 
 ## Core
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
@@ -79,6 +79,7 @@ public class AggregationRuntime implements MemoryCalculable {
     private boolean isFirstEventArrived;
     private long lastExecutorsRefreshedTime = -1;
     private IncrementalDataPurging incrementalDataPurging;
+    private ExpressionExecutor shouldUpdateExpressionExecutor;
 
     public AggregationRuntime(AggregationDefinition aggregationDefinition,
                               Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
@@ -92,7 +93,8 @@ public class AggregationRuntime implements MemoryCalculable {
                               RecreateInMemoryData recreateInMemoryData, boolean processingOnExternalTime,
                               List<List<ExpressionExecutor>> aggregateProcessingExecutorsList,
                               List<GroupByKeyGenerator> groupByKeyGeneratorList,
-                              IncrementalDataPurging incrementalDataPurging) {
+                              IncrementalDataPurging incrementalDataPurging,
+                              ExpressionExecutor shouldUpdateExpressionExecutor) {
         this.aggregationDefinition = aggregationDefinition;
         this.incrementalExecutorMap = incrementalExecutorMap;
         this.aggregationTables = aggregationTables;
@@ -109,6 +111,7 @@ public class AggregationRuntime implements MemoryCalculable {
         this.aggregateProcessingExecutorsList = aggregateProcessingExecutorsList;
         this.groupByKeyGeneratorList = groupByKeyGeneratorList;
         this.incrementalDataPurging = incrementalDataPurging;
+        this.shouldUpdateExpressionExecutor = shouldUpdateExpressionExecutor;
 
         aggregateMetaSteamEvent = new MetaStreamEvent();
         aggregationDefinition.getAttributeList().forEach(aggregateMetaSteamEvent::addOutputData);
@@ -201,7 +204,7 @@ public class AggregationRuntime implements MemoryCalculable {
             return ((IncrementalAggregateCompileCondition) compiledCondition).find(matchingEvent,
                     aggregationDefinition, incrementalExecutorMap, aggregationTables, incrementalDurations,
                     baseExecutors, outputExpressionExecutors, siddhiAppContext,
-                    aggregateProcessingExecutorsList, groupByKeyGeneratorList);
+                    aggregateProcessingExecutorsList, groupByKeyGeneratorList, shouldUpdateExpressionExecutor);
         } finally {
             SnapshotService.getSkipSnapshotableThreadLocal().set(null);
             if (latencyTrackerFind != null && siddhiAppContext.isStatsEnabled()) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/BaseIncrementalValueStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/BaseIncrementalValueStore.java
@@ -42,16 +42,19 @@ public class BaseIncrementalValueStore implements Snapshotable {
     private String elementId;
     private SiddhiAppContext siddhiAppContext;
     private String aggregatorName;
+    private ExpressionExecutor shouldUpdateExpressionExecutor;
 
     public BaseIncrementalValueStore(long timeStamp, List<ExpressionExecutor> expressionExecutors,
                                      StreamEventPool streamEventPool,
-                                     SiddhiAppContext siddhiAppContext, String aggregatorName) {
+                                     SiddhiAppContext siddhiAppContext, String aggregatorName,
+                                     ExpressionExecutor shouldUpdateExpressionExecutor) {
         this.timestamp = timeStamp;
         this.values = new Object[expressionExecutors.size() + 1];
         this.expressionExecutors = expressionExecutors;
         this.streamEventPool = streamEventPool;
         this.siddhiAppContext = siddhiAppContext;
         this.aggregatorName = aggregatorName;
+        this.shouldUpdateExpressionExecutor = shouldUpdateExpressionExecutor;
         if (elementId == null) {
             elementId = "IncrementalBaseStore-" + siddhiAppContext.getElementIdGenerator().createNewId();
         }
@@ -100,9 +103,14 @@ public class BaseIncrementalValueStore implements Snapshotable {
         List<ExpressionExecutor> newExpressionExecutors = new ArrayList<>(expressionExecutors.size());
         expressionExecutors
                 .forEach(expressionExecutor -> newExpressionExecutors.add(expressionExecutor.cloneExecutor(key)));
+        ExpressionExecutor newShouldUpdateExpressionExecutor =
+                (shouldUpdateExpressionExecutor == null) ? null : shouldUpdateExpressionExecutor.cloneExecutor(key);
         return new BaseIncrementalValueStore(timestamp, newExpressionExecutors, streamEventPool, siddhiAppContext,
-                aggregatorName);
+                aggregatorName, newShouldUpdateExpressionExecutor);
+    }
 
+    public ExpressionExecutor getShouldUpdateExpressionExecutor() {
+        return shouldUpdateExpressionExecutor;
     }
 
     @Override

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/executor/incremental/IncrementalShouldUpdateFunctionExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/executor/incremental/IncrementalShouldUpdateFunctionExecutor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.executor.incremental;
+
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.OperationNotSupportedException;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Execute class for shouldUpdate() function.
+ */
+public class IncrementalShouldUpdateFunctionExecutor extends FunctionExecutor {
+    private long lastTimestamp = 0;
+
+    @Override
+    protected void init(ExpressionExecutor[] attributeExpressionExecutors, ConfigReader configReader,
+                        SiddhiAppContext siddhiAppContext) {
+        if (attributeExpressionExecutors.length != 1) {
+            throw new SiddhiAppValidationException("shouldUpdate() function has to have exactly 1 parameter, " +
+                    "currently " + attributeExpressionExecutors.length + " parameters provided");
+        }
+        if (attributeExpressionExecutors[0].getReturnType() != Attribute.Type.LONG) {
+            throw new OperationNotSupportedException("Parameter given for shouldUpdate() function has to be of type " +
+                    "long, but found: " + attributeExpressionExecutors[0].getReturnType());
+        }
+    }
+
+    @Override
+    protected Object execute(Object[] data) {
+        //will not occur
+        return null;
+    }
+
+    /**
+     * return true/false based on timestamp values
+     *
+     * @param data of Long type
+     * @return true/false
+     */
+    @Override
+    protected Object execute(Object data) {
+        long timestamp = (long) data;
+        if (timestamp >= this.lastTimestamp) {
+            this.lastTimestamp = timestamp;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return Attribute.Type.BOOL;
+    }
+
+    @Override
+    public Map<String, Object> currentState() {
+        HashMap<String, Object> state = new HashMap<>();
+        state.put("lastTimestamp", this.lastTimestamp);
+        return state;
+    }
+
+    @Override
+    public void restoreState(Map<String, Object> state) {
+        this.lastTimestamp = ((long) state.get("lastTimestamp"));
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiExtensionLoader.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiExtensionLoader.java
@@ -27,6 +27,7 @@ import org.osgi.framework.BundleListener;
 import org.osgi.framework.wiring.BundleWiring;
 import org.wso2.siddhi.annotation.Extension;
 import org.wso2.siddhi.core.executor.incremental.IncrementalAggregateBaseTimeFunctionExecutor;
+import org.wso2.siddhi.core.executor.incremental.IncrementalShouldUpdateFunctionExecutor;
 import org.wso2.siddhi.core.executor.incremental.IncrementalStartTimeEndTimeFunctionExecutor;
 import org.wso2.siddhi.core.executor.incremental.IncrementalTimeGetTimeZone;
 import org.wso2.siddhi.core.executor.incremental.IncrementalUnixTimeFunctionExecutor;
@@ -86,6 +87,8 @@ public class SiddhiExtensionLoader {
                 IncrementalTimeGetTimeZone.class, siddhiExtensionsMap);
         addExtensionToMap("incrementalAggregator:getAggregationStartTime",
                 IncrementalAggregateBaseTimeFunctionExecutor.class, siddhiExtensionsMap);
+        addExtensionToMap("incrementalAggregator:shouldUpdate",
+                IncrementalShouldUpdateFunctionExecutor.class, siddhiExtensionsMap);
     }
 
     /**

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/AggregationTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/AggregationTestCase.java
@@ -131,7 +131,7 @@ public class AggregationTestCase {
         siddhiManager.createSiddhiAppRuntime(stockStream + query);
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest4"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest4"})
     public void incrementalStreamProcessorTest5() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest5");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -180,7 +180,7 @@ public class AggregationTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest5"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest5"})
     public void incrementalStreamProcessorTest6() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest6");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -287,7 +287,7 @@ public class AggregationTestCase {
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest6"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest6"})
     public void incrementalStreamProcessorTest7() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest7");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -400,7 +400,7 @@ public class AggregationTestCase {
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest7"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest7"})
     public void incrementalStreamProcessorTest8() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest8");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -513,7 +513,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest8"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest8"})
     public void incrementalStreamProcessorTest9() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest9");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -643,7 +643,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
     }
 
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest9"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest9"})
     public void incrementalStreamProcessorTest10() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest10");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -781,7 +781,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest10"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest10"})
     public void incrementalStreamProcessorTest11() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest11");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -845,7 +845,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest11"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest11"})
     public void incrementalStreamProcessorTest12() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest12");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -961,7 +961,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest4"}, expectedExceptions =
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest12"}, expectedExceptions =
             SiddhiAppCreationException.class)
     public void incrementalStreamProcessorTest13() {
         LOG.info("incrementalStreamProcessorTest13");
@@ -1384,7 +1384,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest21"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest21"})
     public void incrementalStreamProcessorTest22() throws InterruptedException {
         // Error gets logged at AbstractStreamProcessor level and event gets dropped. Hence no expectedExceptions for
         // this test case
@@ -1424,7 +1424,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest21"})
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest22"})
     public void incrementalStreamProcessorTest23() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest23");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1475,7 +1475,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest23"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest23"})
     public void incrementalStreamProcessorTest24() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest24");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1525,7 +1525,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest24"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest24"})
     public void incrementalStreamProcessorTest25() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest25");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1585,8 +1585,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-
-    @Test(dependsOnMethods = "incrementalStreamProcessorTest25", enabled = false)
+    @Test(dependsOnMethods = "incrementalStreamProcessorTest25")
     public void incrementalStreamProcessorTest26() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest26");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1681,7 +1680,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest21"}, expectedExceptions =
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest26"}, expectedExceptions =
             StoreQueryCreationException.class)
     public void incrementalStreamProcessorTest27() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest27");
@@ -1801,7 +1800,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest30"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest30"})
     public void incrementalStreamProcessorTest31() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest31");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1869,7 +1868,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest31"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest31"})
     public void incrementalStreamProcessorTest32() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest32");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1925,7 +1924,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest32"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest32"})
     public void incrementalStreamProcessorTest33() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest33");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -1981,7 +1980,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest33"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest33"})
     public void incrementalStreamProcessorTest34() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest34");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2037,7 +2036,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest34"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest34"})
     public void incrementalStreamProcessorTest35() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest35");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2093,7 +2092,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest30"}, expectedExceptions =
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest35"}, expectedExceptions =
             StoreQueryCreationException.class)
     public void incrementalStreamProcessorTest36() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest36");
@@ -2153,7 +2152,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest37"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest37"})
     public void incrementalStreamProcessorTest38() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest38");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2249,7 +2248,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
             Thread.sleep(100);
 
             List<Object[]> expected = Arrays.asList(
-                    new Object[]{198.0, 1980.0, 300f},
+                    new Object[]{198.0, 1980.0, 3500f},
                     new Object[]{400.0, 400.0, 3600f},
                     new Object[]{700.0, 700.0, 14000f},
                     new Object[]{600.0, 600.0, 3600f}
@@ -2264,7 +2263,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest38"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest38"})
     public void incrementalStreamProcessorTest39() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest39");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2395,7 +2394,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest39"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest39"})
     public void incrementalStreamProcessorTest40() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest40");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2434,7 +2433,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest40"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest40"})
     public void incrementalStreamProcessorTest41() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest41");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2532,7 +2531,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest41"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest41"})
     public void incrementalStreamProcessorTest42() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest42");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2630,7 +2629,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest42"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest42"})
     public void incrementalStreamProcessorTest43() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest43");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2728,7 +2727,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest37"})
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest43"})
     public void incrementalStreamProcessorTest44() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest44");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -2784,7 +2783,6 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
             siddhiAppRuntime.shutdown();
         }
     }
-
 
     @Test(dependsOnMethods = {"incrementalStreamProcessorTest44"})
     public void incrementalStreamProcessorTest45() throws InterruptedException {
@@ -3064,8 +3062,7 @@ AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
         }
     }
 
-
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest48"}, enabled = false)
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest48"})
     public void incrementalStreamProcessorTest49() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest49 - Aggregate on system timestamp and retrieval on non root duration");
         SiddhiManager siddhiManager = new SiddhiManager();

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/LatestAggregationTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/LatestAggregationTestCase.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.aggregation;
+
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.core.util.SiddhiTestHelper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LatestAggregationTestCase {
+
+    private static final Logger LOG = Logger.getLogger(LatestAggregationTestCase.class);
+    private AtomicInteger inEventCount;
+    private AtomicInteger removeEventCount;
+    private boolean eventArrived;
+    private List<Object[]> inEventsList;
+    private List<Object[]> removeEventsList;
+
+    @BeforeMethod
+    public void init() {
+        inEventCount = new AtomicInteger(0);
+        removeEventCount = new AtomicInteger(0);
+        eventArrived = false;
+        inEventsList = new ArrayList<>();
+        removeEventsList = new ArrayList<>();
+    }
+
+    @Test
+    public void latestTestCase() throws InterruptedException {
+        LOG.info("latestTestCase: testing latest incremental aggregator");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "define aggregation stockAggregation " +
+                        "from stockStream " +
+                        "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
+                        "aggregate by timestamp every sec...year ;" +
+
+                        "define stream inputStream (symbol string); " +
+
+                        "@info(name = 'query1') " +
+                        "from inputStream as i join stockAggregation as s " +
+                        "within 1496200000000L, 1596535449000L " +
+                        "per \"seconds\" " +
+                        "select AGG_TIMESTAMP, s.symbol, s.latestPrice " +
+                        "order by AGG_TIMESTAMP " +
+                        "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                    if (removeEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : removeEvents) {
+                            removeEventsList.add(event.getData());
+                            removeEventCount.incrementAndGet();
+                        }
+                    }
+                    eventArrived = true;
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+            Thread.sleep(10000);
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{1496289950000L, "WSO22", 750f},
+                    new Object[]{1496289952000L, "WSO24", 1600f},
+                    new Object[]{1496289954000L, "IBM1", 10200f},
+                    new Object[]{1496289956000L, "IBM1", 3500f}
+            );
+            SiddhiTestHelper.waitForEvents(100, 4, inEventCount, 10000);
+            AssertJUnit.assertEquals("In events matched", true,
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+            AssertJUnit.assertEquals("Remove events matched", true,
+                    SiddhiTestHelper.isUnsortedEventsMatch(removeEventsList, expected));
+            AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
+            AssertJUnit.assertEquals("Number of remove events", 4, removeEventCount.get());
+            AssertJUnit.assertEquals("Event arrived", true, eventArrived);
+        }  finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/siddhi/issues/899

## Goals
The latest aggregator will be called to all attributes other than group by attributes and calculations.

## Approach
This will store an additional information "AGG_LAST_EVENT_TIMESTAMP" to the aggregation inner tables to track the last arrived events timestamp. Thus latest value can be calculated from the above column.

## Documentation
N/A.. as this is a bug fix

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
