### PR TITLE
Fix for the issue https://github.com/wso2/product-sp/issues/835

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataPurging.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataPurging.java
@@ -196,6 +196,7 @@ public class IncrementalDataPurging implements Runnable {
 
         for (Map.Entry<TimePeriod.Duration, Table> entry : aggregationTables.entrySet()) {
             if (!retentionPeriods.get(entry.getKey()).equals(RETAIN_ALL)) {
+                eventChunk.clear();
                 purgeTime = currentTime - retentionPeriods.get(entry.getKey());
                 purgeTimeArray[0] = purgeTime;
                 StateEvent secEvent = createStreamEvent(purgeTimeArray, currentTime);


### PR DESCRIPTION
## Purpose
eventChunk will be cleaned before adding a new purging event with purging time and the current timestamp. So that the issue which reported in https://github.com/wso2/product-sp/issues/835 get fixed

