### PR TITLE
 Improve the table connection retrying mechanism

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/Table.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/Table.java
@@ -156,7 +156,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing add for events '" +
                     addingEventChunk + "', operation busy waiting at Table '" + tableDefinition.getId() +
                     "' as its trying to reconnect!");
-            busyWaitWhileConnect();
+            waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
                     "' has become available for add operation for events '" + addingEventChunk + "'");
             addEvents(addingEventChunk, noOfEvents);
@@ -195,7 +195,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing find for events '" +
                     matchingEvent + "', operation busy waiting at Table '" + tableDefinition.getId() +
                     "' as its trying to reconnect!");
-            busyWaitWhileConnect();
+            waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
                     "' has become available for find operation for events '" + matchingEvent + "'");
             return find(matchingEvent, compiledCondition);
@@ -235,7 +235,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing delete for events '" +
                     deletingEventChunk + "', operation busy waiting at Table '" + tableDefinition.getId() +
                     "' as its trying to reconnect!");
-            busyWaitWhileConnect();
+            waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
                     "' has become available for delete operation for events '" + deletingEventChunk + "'");
             deleteEvents(deletingEventChunk, compiledCondition, noOfEvents);
@@ -277,7 +277,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing update for events '" +
                     updatingEventChunk + "', operation busy waiting at Table '" + tableDefinition.getId() +
                     "' as its trying to reconnect!");
-            busyWaitWhileConnect();
+            waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
                     "' has become available for update operation for events '" + updatingEventChunk + "'");
             updateEvents(updatingEventChunk, compiledCondition, compiledUpdateSet, noOfEvents);
@@ -323,7 +323,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing upsert for events '" +
                     updateOrAddingEventChunk + "', operation busy waiting at Table '" + tableDefinition.getId() +
                     "' as its trying to reconnect!");
-            busyWaitWhileConnect();
+            waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
                     "' has become available for upsert operation for events '" + updateOrAddingEventChunk + "'");
             updateOrAddEvents(updateOrAddingEventChunk, compiledCondition, compiledUpdateSet,
@@ -368,7 +368,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing contains check for event '" +
                     matchingEvent + "', operation busy waiting at Table '" + tableDefinition.getId() +
                     "' as its trying to reconnect!");
-            busyWaitWhileConnect();
+            waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
                     "' has become available for contains check operation for matching event '" + matchingEvent + "'");
             return containsEvent(matchingEvent, compiledCondition);
@@ -418,7 +418,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
      * Busy wait the threads which bind to this object and control the execution flow
      * until table connection recovered.
      */
-    private void busyWaitWhileConnect() {
+    private void waitWhileConnect() {
         try {
             synchronized (this) {
                 while (isTryingToConnect.get()) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/transport/BackoffRetryCounter.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/transport/BackoffRetryCounter.java
@@ -33,7 +33,7 @@ public class BackoffRetryCounter {
     }
 
     public synchronized void increment() {
-        if (intervalIndex < timeIntervals.length - 2) {
+        if (intervalIndex < timeIntervals.length - 1) {
             intervalIndex++;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -185,13 +185,6 @@
                 <version>${jackson-datatype-joda-version}</version>
             </dependency>
 
-            <!-- Event Tables -->
-            <dependency>
-                <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>${hikari.version}</version>
-            </dependency>
-
             <!-- Siddhi Doc Generator -->
             <dependency>
                 <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to improve the table connection exception handling mechanism. As per the  current implementation events are drop while the connection retrying, as in like when a Siddhi app consume messages from a Kafka source and insert each message into RDBMS table, and if there is a connection issue occurs at the database, siddhi app will drop the event at RDBMS event table when it's trying to perform add operation and then continue the messages consuming at Kafka source.

Other Fixes:
- Fix the BackoffRetryCounter loop count
- Remove unused dependency versions

## Goals
> The Siddhi app execution flow busy-wait until the table connection recovered.

## Approach
> Improve the table connection retrying mechanism by introducing a new function call busy wait, which is wait for the thread notification after the connection recovered.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A

 
## Learning
> N/A
