### PR TITLE
Siddhi delay window

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.query.processor.stream.window;
+
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.annotation.Parameter;
+import org.wso2.siddhi.annotation.util.DataType;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.event.ComplexEventChunk;
+import org.wso2.siddhi.core.event.state.StateEvent;
+import org.wso2.siddhi.core.event.stream.StreamEvent;
+import org.wso2.siddhi.core.event.stream.StreamEventCloner;
+import org.wso2.siddhi.core.event.stream.holder.SnapshotableStreamEventQueue;
+import org.wso2.siddhi.core.executor.ConstantExpressionExecutor;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.executor.VariableExpressionExecutor;
+import org.wso2.siddhi.core.query.processor.Processor;
+import org.wso2.siddhi.core.table.Table;
+import org.wso2.siddhi.core.util.collection.operator.CompiledCondition;
+import org.wso2.siddhi.core.util.collection.operator.MatchingMetaInfoHolder;
+import org.wso2.siddhi.core.util.collection.operator.Operator;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.core.util.parser.OperatorParser;
+import org.wso2.siddhi.core.util.snapshot.state.SnapshotStateList;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
+import org.wso2.siddhi.query.api.expression.Expression;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of {@link WindowProcessor} which represent a Window operating based on delay time.
+ */
+@Extension(
+        name = "delay",
+        namespace = "",
+        description = "A delay window holds events that arrived " +
+                "for a given delay time period before processing them.",
+        parameters = {
+                @Parameter(name = "window.delay",
+                        description = "The time period(sec, min, ms) for which " +
+                                " the window should delay the events.",
+                        type = {DataType.INT, DataType.LONG, DataType.TIME})
+        },
+        examples = {
+                @Example(
+                        syntax = "define window delayWindow(symbol string, volume int) delay(20);\n" +
+                                "define stream inputStream(symbol string, volume int);\n" +
+                                "define stream deliveryStream(symbol string);\n" +
+                                "define stream outputStream(symbol string);\n" +
+                                "\n" +
+                                "@info(name='query1') \n" +
+                                "from inputStream\n" +
+                                "select symbol, volume\n" +
+                                "insert into delayWindow;\n" +
+                                "\n" +
+                                "@info(name='query2') \n" +
+                                "from delayWindow join deliveryStream\n" +
+                                "on delayWindow.symbol == deliveryStream.symbol\n" +
+                                "select delayWindow.symbol\n" +
+                                "insert into outputStream;",
+                        description = "This will delay the events from inputStream for 20 milliseconds " +
+                                "and match them with events arrived from deliveryStream  "
+                )
+        }
+)
+
+public class DelayWindowProcessor extends TimeWindowProcessor {
+
+    private long delayInMilliSeconds;
+    private SiddhiAppContext siddhiAppContext;
+    private SnapshotableStreamEventQueue delayedEventQueue;
+    private volatile long lastTimestamp = Long.MIN_VALUE;
+
+    @Override
+    protected void init(ExpressionExecutor[] attributeExpressionExecutors, ConfigReader configReader, boolean
+            outputExpectsExpiredEvents, SiddhiAppContext siddhiAppContext) {
+        this.siddhiAppContext = siddhiAppContext;
+        this.delayedEventQueue = new SnapshotableStreamEventQueue(streamEventClonerHolder);
+        if (attributeExpressionExecutors.length == 1) {
+            if (attributeExpressionExecutors[0] instanceof ConstantExpressionExecutor) {
+                if (attributeExpressionExecutors[0].getReturnType() == Attribute.Type.INT ||
+                        attributeExpressionExecutors[0].getReturnType() == Attribute.Type.LONG) {
+                    delayInMilliSeconds = Long.parseLong(((ConstantExpressionExecutor) attributeExpressionExecutors[0])
+                            .getValue().toString());
+
+                } else {
+                    throw new SiddhiAppValidationException("Delay window's parameter attribute should be either " +
+                            "int or long, but found " + attributeExpressionExecutors[0].getReturnType());
+                }
+            } else {
+                throw new SiddhiAppValidationException("Delay window should have constant parameter attribute but " +
+                        "found a dynamic attribute " + attributeExpressionExecutors[0].getClass().getCanonicalName());
+            }
+        } else {
+            throw new SiddhiAppValidationException("Delay window should only have one parameter (<int|long|time> " +
+                    "delayTime), but found " + attributeExpressionExecutors.length + " input attributes");
+        }
+    }
+
+    @Override
+    protected void process(ComplexEventChunk<StreamEvent> streamEventChunk, Processor nextProcessor,
+                           StreamEventCloner streamEventCloner) {
+        synchronized (this) {
+
+            while (streamEventChunk.hasNext()) {
+                StreamEvent streamEvent = streamEventChunk.next();
+                long currentTime = siddhiAppContext.getTimestampGenerator().currentTime();
+
+                delayedEventQueue.reset();
+                while (delayedEventQueue.hasNext()) {
+                    StreamEvent delayedEvent = delayedEventQueue.next();
+                    //check if the event has delayed expected time period
+                    if (currentTime >= delayedEvent.getTimestamp() + delayInMilliSeconds) {
+                        delayedEventQueue.remove();
+                        //insert delayed event before the current event to stream chunk
+                        streamEventChunk.insertBeforeCurrent(delayedEvent);
+                    } else {
+                        break;
+                    }
+                }
+
+                if (streamEvent.getType() == StreamEvent.Type.CURRENT) {
+                    this.delayedEventQueue.add(streamEvent);
+
+                    if (lastTimestamp < streamEvent.getTimestamp()) {
+                        getScheduler().notifyAt(streamEvent.getTimestamp() + delayInMilliSeconds);
+                        lastTimestamp = streamEvent.getTimestamp();
+                    }
+                }
+                //current events are not processed, so remove the current event from the stream chunk
+                streamEventChunk.remove();
+            }
+            delayedEventQueue.reset();
+        }
+        //only pass to next processor if there are any events in the stream chunk
+        if (streamEventChunk.getFirst() != null) {
+            nextProcessor.process(streamEventChunk);
+        }
+    }
+
+    @Override
+    public synchronized StreamEvent find(StateEvent matchingEvent, CompiledCondition compiledCondition) {
+        return ((Operator) compiledCondition).find(matchingEvent, delayedEventQueue, streamEventCloner);
+    }
+
+    @Override
+    public CompiledCondition compileCondition(Expression condition, MatchingMetaInfoHolder matchingMetaInfoHolder,
+                                              SiddhiAppContext siddhiAppContext,
+                                              List<VariableExpressionExecutor> variableExpressionExecutors,
+                                              Map<String, Table> tableMap, String queryName) {
+        return OperatorParser.constructOperator(delayedEventQueue, condition, matchingMetaInfoHolder,
+                siddhiAppContext, variableExpressionExecutors, tableMap, this.queryName);
+    }
+
+    @Override
+    public Map<String, Object> currentState() {
+        Map<String, Object> state = new HashMap<>();
+        state.put("DelayedEventQueue", delayedEventQueue.getSnapshot());
+        return state;
+    }
+
+    @Override
+    public void restoreState(Map<String, Object> state) {
+        delayedEventQueue.restore((SnapshotStateList) state.get("DelayedEventQueue"));
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
@@ -77,8 +77,9 @@ import java.util.Map;
                                 "on delayWindow.symbol == deliveryStream.symbol\n" +
                                 "select delayWindow.symbol\n" +
                                 "insert into outputStream;",
-                        description = "This will delay the events from purchaseStream for 20 milliseconds " +
-                                "and match them with events arrived from deliveryStream  "
+                        description = "This will delay the events from purchaseStream for 1 hour " +
+                                "and match them with events arrived from deliveryStream to check " +
+                                "if delivery of the purchased item is done within 1 hour "
                 )
         }
 )

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
@@ -62,13 +62,13 @@ import java.util.Map;
         },
         examples = {
                 @Example(
-                        syntax = "define window delayWindow(symbol string, volume int) delay(20);\n" +
-                                "define stream inputStream(symbol string, volume int);\n" +
+                        syntax = "define window delayWindow(symbol string, volume int) delay(1 hour);\n" +
+                                "define stream purchaseStream(symbol string, volume int);\n" +
                                 "define stream deliveryStream(symbol string);\n" +
                                 "define stream outputStream(symbol string);\n" +
                                 "\n" +
                                 "@info(name='query1') \n" +
-                                "from inputStream\n" +
+                                "from purchaseStream\n" +
                                 "select symbol, volume\n" +
                                 "insert into delayWindow;\n" +
                                 "\n" +
@@ -77,7 +77,7 @@ import java.util.Map;
                                 "on delayWindow.symbol == deliveryStream.symbol\n" +
                                 "select delayWindow.symbol\n" +
                                 "insert into outputStream;",
-                        description = "This will delay the events from inputStream for 20 milliseconds " +
+                        description = "This will delay the events from purchaseStream for 20 milliseconds " +
                                 "and match them with events arrived from deliveryStream  "
                 )
         }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/DelayWindowProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -101,7 +101,6 @@ public class DelayWindowProcessor extends TimeWindowProcessor {
                         attributeExpressionExecutors[0].getReturnType() == Attribute.Type.LONG) {
                     delayInMilliSeconds = Long.parseLong(((ConstantExpressionExecutor) attributeExpressionExecutors[0])
                             .getValue().toString());
-
                 } else {
                     throw new SiddhiAppValidationException("Delay window's parameter attribute should be either " +
                             "int or long, but found " + attributeExpressionExecutors[0].getReturnType());

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.siddhi.core.window;
 
-import com.sun.org.glassfish.gmbal.Description;
 import org.apache.log4j.Logger;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -64,8 +63,7 @@ public class DelayWindowTestCase {
         error = true;
     }
 
-    @Test
-    @Description("Check if Siddhi App is created successfully when only one parameter of type either " +
+    @Test(description = "Check if Siddhi App is created successfully when only one parameter of type either " +
             "int or long is specified")
     public void delayWindowTest0() {
         log.info("DelayWindow Test0 : Testing window parameter definition1");
@@ -85,8 +83,7 @@ public class DelayWindowTestCase {
         AssertJUnit.assertTrue(error);
     }
 
-    @Test
-    @Description("Check if Siddhi App Creation fails when more than one parameter is included")
+    @Test(description = "Check if Siddhi App Creation fails when more than one parameter is included")
     public void delayWindowTest1() {
         log.info("DelayWindow Test1 : Testing window parameter definition2");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -105,8 +102,7 @@ public class DelayWindowTestCase {
         AssertJUnit.assertFalse(error);
     }
 
-    @Test
-    @Description("Check if Siddhi App Creation fails when the type of parameter is neither int or long")
+    @Test(description = "Check if Siddhi App Creation fails when the type of parameter is neither int or long")
     public void delayWindowTest2() {
         log.info("DelayWindow Test2 : Testing window parameter definition3");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -125,8 +121,7 @@ public class DelayWindowTestCase {
         AssertJUnit.assertFalse(error);
     }
 
-    @Test
-    @Description("Check whether the events are processed when using delay window")
+    @Test(description = "Check whether the events are processed when using delay window")
     public void delayWindowTest3() throws InterruptedException {
         log.info("DelayWindow Test3: Testing delay window event processing");
 
@@ -174,8 +169,7 @@ public class DelayWindowTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test
-    @Description("Check whether delay window join is working properly")
+    @Test(description = "Check whether delay window join is working properly")
     public void delayWindowTest4() throws InterruptedException {
         log.info("DelayWindow Test4 : Testing delay window joins");
 
@@ -223,8 +217,7 @@ public class DelayWindowTestCase {
         }
     }
 
-    @Test
-    @Description("Check whether aggregations are done correctly when using delay window ")
+    @Test(description = "Check whether aggregations are done correctly when using delay window ")
     public void delayWindowTest5() {
         log.info("DelayWindow Test5 : Testing delay window for Aggregation");
 
@@ -287,8 +280,7 @@ public class DelayWindowTestCase {
         }
     }
 
-    @Test
-    @Description("Check whether the events are being actually delayed, for the given time period.")
+    @Test(description = "Check whether the events are being actually delayed, for the given time period.")
     public void delayWindowTest6() throws InterruptedException {
         log.info("DelayWindow Test6: Testing delay time ");
 
@@ -347,8 +339,7 @@ public class DelayWindowTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test
-    @Description("Check if events are persisted when using delay window")
+    @Test(description = "Check if events are persisted when using delay window")
     public void delayWindowTest7() throws InterruptedException {
         log.info("DelayWindow Test7: Testing persistence ");
 

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -35,7 +35,6 @@ import org.wso2.siddhi.core.util.EventPrinter;
 import org.wso2.siddhi.core.util.SiddhiTestHelper;
 import org.wso2.siddhi.core.util.persistence.InMemoryPersistenceStore;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
-import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -74,8 +73,8 @@ public class DelayWindowTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test(description = "Check if Siddhi App Creation fails when more than one parameter is included", expectedExceptions = SiddhiAppCreationException.class)
-
+    @Test(description = "Check if Siddhi App Creation fails when more than one parameter is included",
+            expectedExceptions = SiddhiAppCreationException.class)
     public void delayWindowTest1() {
         log.info("DelayWindow Test1 : Testing window parameter definition2");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -85,7 +84,8 @@ public class DelayWindowTestCase {
             siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
         } catch (SiddhiAppCreationException e) {
             error = false;
-            AssertJUnit.assertEquals("Delay window should only have one parameter (<int|long|time> delayTime), but found 2 input attributes", e.getCause().getMessage());
+            AssertJUnit.assertEquals("Delay window should only have one parameter (<int|long|time> delayTime), " +
+                    "but found 2 input attributes", e.getCause().getMessage());
             throw e;
         } finally {
             if (siddhiAppRuntime != null) {
@@ -94,7 +94,8 @@ public class DelayWindowTestCase {
         }
     }
 
-    @Test(description = "Check if Siddhi App Creation fails when the type of parameter is neither int or long", expectedExceptions = SiddhiAppCreationException.class)
+    @Test(description = "Check if Siddhi App Creation fails when the type of parameter is neither int or long",
+            expectedExceptions = SiddhiAppCreationException.class)
     public void delayWindowTest2() {
         log.info("DelayWindow Test2 : Testing window parameter definition3");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -104,7 +105,8 @@ public class DelayWindowTestCase {
             siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
         } catch (SiddhiAppCreationException e) {
             error = false;
-            AssertJUnit.assertEquals("Delay window's parameter attribute should be either int or long, but found STRING", e.getCause().getMessage());
+            AssertJUnit.assertEquals("Delay window's parameter attribute should be either int or long, " +
+                    "but found STRING", e.getCause().getMessage());
             throw e;
         } finally {
             if (siddhiAppRuntime != null) {

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -35,6 +35,7 @@ import org.wso2.siddhi.core.util.EventPrinter;
 import org.wso2.siddhi.core.util.SiddhiTestHelper;
 import org.wso2.siddhi.core.util.persistence.InMemoryPersistenceStore;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -68,41 +69,32 @@ public class DelayWindowTestCase {
     public void delayWindowTest0() {
         log.info("DelayWindow Test0 : Testing window parameter definition1");
         SiddhiManager siddhiManager = new SiddhiManager();
-        String query = "define window eventWindow(symbol string, price int, volume float) delay(2 sec)";
-        SiddhiAppRuntime siddhiAppRuntime = null;
-        try {
-            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
-        } catch (SiddhiAppCreationException e) {
-            error = false;
-            log.info(e.getCause());
-        } finally {
-            if (siddhiAppRuntime != null) {
-                siddhiAppRuntime.shutdown();
-            }
-        }
-        AssertJUnit.assertTrue(error);
+        String query = "define window eventWindow(symbol string, price int, volume float) delay(1 hour)";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
+        siddhiAppRuntime.shutdown();
     }
 
-    @Test(description = "Check if Siddhi App Creation fails when more than one parameter is included")
+    @Test(description = "Check if Siddhi App Creation fails when more than one parameter is included", expectedExceptions = SiddhiAppCreationException.class)
+
     public void delayWindowTest1() {
         log.info("DelayWindow Test1 : Testing window parameter definition2");
         SiddhiManager siddhiManager = new SiddhiManager();
         String query = "define window eventWindow(symbol string, price int, volume float) delay(2,3) ";
         SiddhiAppRuntime siddhiAppRuntime = null;
-        try {
+       try {
             siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
-        } catch (SiddhiAppCreationException e1) {
+        } catch (SiddhiAppCreationException e) {
             error = false;
-            log.info(e1.getCause());
+            AssertJUnit.assertEquals("Delay window should only have one parameter (<int|long|time> delayTime), but found 2 input attributes", e.getCause().getMessage());
+            throw e;
         } finally {
             if (siddhiAppRuntime != null) {
                 siddhiAppRuntime.shutdown();
             }
         }
-        AssertJUnit.assertFalse(error);
     }
 
-    @Test(description = "Check if Siddhi App Creation fails when the type of parameter is neither int or long")
+    @Test(description = "Check if Siddhi App Creation fails when the type of parameter is neither int or long", expectedExceptions = SiddhiAppCreationException.class)
     public void delayWindowTest2() {
         log.info("DelayWindow Test2 : Testing window parameter definition3");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -112,13 +104,13 @@ public class DelayWindowTestCase {
             siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
         } catch (SiddhiAppCreationException e) {
             error = false;
-            log.info(e.getCause());
+            AssertJUnit.assertEquals("Delay window's parameter attribute should be either int or long, but found STRING", e.getCause().getMessage());
+            throw e;
         } finally {
             if (siddhiAppRuntime != null) {
                 siddhiAppRuntime.shutdown();
             }
         }
-        AssertJUnit.assertFalse(error);
     }
 
     @Test(description = "Check whether the events are processed when using delay window")

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -1,20 +1,21 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.siddhi.core.window;
 
 import org.apache.log4j.Logger;

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.siddhi.core.window;
 
+import com.sun.org.glassfish.gmbal.Description;
 import org.apache.log4j.Logger;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -37,6 +38,10 @@ import org.wso2.siddhi.core.util.persistence.InMemoryPersistenceStore;
 import org.wso2.siddhi.core.util.persistence.PersistenceStore;
 
 import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Delay window implementation testcase
+ */
 
 public class DelayWindowTestCase {
     private static final Logger log = Logger.getLogger(DelayWindowTestCase.class);
@@ -60,6 +65,8 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check if Siddhi App is created successfully when only one parameter of type either " +
+            "int or long is specified")
     public void delayWindowTest0() {
         log.info("DelayWindow Test0 : Testing window parameter definition1");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -79,6 +86,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check if Siddhi App Creation fails when more than one parameter is included")
     public void delayWindowTest1() {
         log.info("DelayWindow Test1 : Testing window parameter definition2");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -98,6 +106,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check if Siddhi App Creation fails when the type of parameter is neither int or long")
     public void delayWindowTest2() {
         log.info("DelayWindow Test2 : Testing window parameter definition3");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -117,6 +126,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check whether the events are processed when using delay window")
     public void delayWindowTest3() throws InterruptedException {
         log.info("DelayWindow Test3: Testing delay window event processing");
 
@@ -165,6 +175,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check whether delay window join is working properly")
     public void delayWindowTest4() throws InterruptedException {
         log.info("DelayWindow Test4 : Testing delay window joins");
 
@@ -213,6 +224,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check whether aggregations are done correctly when using delay window ")
     public void delayWindowTest5() {
         log.info("DelayWindow Test5 : Testing delay window for Aggregation");
 
@@ -276,6 +288,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check whether the events are being actually delayed, for the given time period.")
     public void delayWindowTest6() throws InterruptedException {
         log.info("DelayWindow Test6: Testing delay time ");
 
@@ -335,6 +348,7 @@ public class DelayWindowTestCase {
     }
 
     @Test
+    @Description("Check if events are persisted when using delay window")
     public void delayWindowTest7() throws InterruptedException {
         log.info("DelayWindow Test7: Testing persistence ");
 

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.window;
+
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.stream.output.StreamCallback;
+import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.core.util.SiddhiTestHelper;
+import org.wso2.siddhi.core.util.persistence.InMemoryPersistenceStore;
+import org.wso2.siddhi.core.util.persistence.PersistenceStore;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DelayWindowTestCase {
+    private static final Logger log = Logger.getLogger(DelayWindowTestCase.class);
+    private boolean eventArrived;
+    private AtomicInteger count = new AtomicInteger(0);
+    private Long lastValue;
+    private double averageValue;
+    private int removeEventCount;
+    private int inEventCount;
+    private boolean error;
+
+    @BeforeMethod
+    public void init() {
+        count.set(0);
+        eventArrived = false;
+        lastValue = Long.valueOf(0);
+        averageValue = Double.valueOf(0);
+        removeEventCount = 0;
+        inEventCount = 0;
+        error = true;
+    }
+
+    @Test
+    public void delayWindowTest0() {
+        log.info("DelayWindow Test0 : Testing window parameter definition1");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "define window eventWindow(symbol string, price int, volume float) delay(2 sec)";
+        SiddhiAppRuntime siddhiAppRuntime = null;
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
+        } catch (SiddhiAppCreationException e) {
+            error = false;
+            log.info(e.getCause());
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+        }
+        AssertJUnit.assertTrue(error);
+    }
+
+    @Test
+    public void delayWindowTest1() {
+        log.info("DelayWindow Test1 : Testing window parameter definition2");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "define window eventWindow(symbol string, price int, volume float) delay(2,3) ";
+        SiddhiAppRuntime siddhiAppRuntime = null;
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
+        } catch (SiddhiAppCreationException e1) {
+            error = false;
+            log.info(e1.getCause());
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+        }
+        AssertJUnit.assertFalse(error);
+    }
+
+    @Test
+    public void delayWindowTest2() {
+        log.info("DelayWindow Test2 : Testing window parameter definition3");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String query = "define window eventWindow(symbol string, price int, volume float) delay('abc') ";
+        SiddhiAppRuntime siddhiAppRuntime = null;
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(query);
+        } catch (SiddhiAppCreationException e) {
+            error = false;
+            log.info(e.getCause());
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+        }
+        AssertJUnit.assertFalse(error);
+    }
+
+    @Test
+    public void delayWindowTest3() throws InterruptedException {
+        log.info("DelayWindow Test3: Testing delay window event processing");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String cseEventStream = "" +
+                "define stream cseEventStream (symbol string, price float, volume int); " +
+                "define window csEventWindow (symbol string, price float, volume int) delay(2 sec) output all events;";
+
+        String query = "" +
+                "@info(name = 'query0') " +
+                "from cseEventStream " +
+                "insert into csEventWindow; " +
+                "" +
+                "@info(name = 'query1') " +
+                "from csEventWindow " +
+                "select symbol,price,volume " +
+                "insert all events into outputStream;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(cseEventStream + query);
+
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                count.addAndGet(events.length);
+                eventArrived = true;
+                for (Event event : events) {
+                    AssertJUnit.assertTrue(("IBM".equals(event.getData(0)) || "WSO2".equals(event.getData(0))));
+                }
+            }
+        });
+
+        InputHandler input = siddhiAppRuntime.getInputHandler("cseEventStream");
+        siddhiAppRuntime.start();
+
+        input.send(new Object[]{"IBM", 700f, 0});
+        input.send(new Object[]{"IBM", 750f, 0});
+        input.send(new Object[]{"IBM", 800f, 0});
+        input.send(new Object[]{"WSO2", 60.5f, 1});
+
+        SiddhiTestHelper.waitForEvents(100, 4, count, 2000);
+        AssertJUnit.assertEquals(4, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void delayWindowTest4() throws InterruptedException {
+        log.info("DelayWindow Test4 : Testing delay window joins");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream cseEventStream (symbol string, price float, volume int); " +
+                "define stream twitterStream (user string, tweet string, company string); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from cseEventStream#window.delay(1 sec) join twitterStream#window.delay(1 sec) " +
+                "on cseEventStream.symbol== twitterStream.company " +
+                "select cseEventStream.symbol as symbol, twitterStream.tweet, cseEventStream.price " +
+                "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        try {
+            siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+                @Override
+                public void receive(Event[] events) {
+                    EventPrinter.print(events);
+                    if (events != null) {
+                        count.addAndGet(events.length);
+                    }
+                    AssertJUnit.assertTrue("WSO2".equals(events[0].getData(0)) || "IBM".equals(events[0].getData(0)));
+                    eventArrived = true;
+                }
+            });
+            InputHandler cseEventStreamHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
+            InputHandler twitterStreamHandler = siddhiAppRuntime.getInputHandler("twitterStream");
+            siddhiAppRuntime.start();
+
+            cseEventStreamHandler.send(new Object[]{"WSO2", 55.6f, 100});
+            cseEventStreamHandler.send(new Object[]{"IBM", 75.6f, 100});
+            twitterStreamHandler.send(new Object[]{"User1", "Hello World", "WSO2"});
+            twitterStreamHandler.send(new Object[]{"User2", "Hello World2", "IBM"});
+
+            Thread.sleep(1100);
+            cseEventStreamHandler.send(new Object[]{"WSO2", 57.6f, 100});
+
+            SiddhiTestHelper.waitForEvents(100, 2, count, 2000);
+            AssertJUnit.assertEquals(2, count.get());
+            AssertJUnit.assertTrue(eventArrived);
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test
+    public void delayWindowTest5() {
+        log.info("DelayWindow Test5 : Testing delay window for Aggregation");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String eventStream = "" +
+                "define stream CargoStream (weight int); " +
+                "define stream OutputStream(weight int, totalWeight long, averageWeight double); ";
+        String query = "" +
+                "@info(name='CargoWeightQuery') " +
+                "from CargoStream#window.delay(1 sec) " +
+                "select weight, sum(weight) as totalWeight, avg(weight) as averageWeight " +
+                "insert into OutputStream;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(eventStream + query);
+
+        siddhiAppRuntime.addCallback("CargoWeightQuery", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        StreamCallback callBack = new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    lastValue = (Long) event.getData(1);
+                    averageValue = (Double) event.getData(2);
+                }
+            }
+        };
+
+        siddhiAppRuntime.addCallback("OutputStream", callBack);
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("CargoStream");
+        siddhiAppRuntime.start();
+        try {
+            inputHandler.send(new Object[]{1000});
+            inputHandler.send(new Object[]{1500});
+
+            SiddhiTestHelper.waitForEvents(100, 2, count, 2000);
+            AssertJUnit.assertEquals(2, inEventCount);
+            AssertJUnit.assertEquals(0, removeEventCount);
+            AssertJUnit.assertEquals(Long.valueOf(2500), lastValue);
+            AssertJUnit.assertEquals(Double.valueOf(1250), averageValue);
+
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test
+    public void delayWindowTest6() throws InterruptedException {
+        log.info("DelayWindow Test6: Testing delay time ");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String cseEventStream = "" +
+                "define window delayWindow(symbol string, volume int) delay(1450);" +
+                "define stream inputStream(symbol string, volume int);" +
+                "define window timeWindow(symbol string) time(2 sec);";
+
+        String query = "" +
+                "@info(name='query1') " +
+                "from inputStream " +
+                "select symbol, volume " +
+                "insert into delayWindow; " +
+                "" +
+                "@info(name = 'query2') " +
+                "from delayWindow " +
+                "select symbol, volume " +
+                "insert into analyzeStream; " +
+                "" +
+                "@info(name='query3') " +
+                "from inputStream " +
+                "select symbol " +
+                "insert into timeWindow; " +
+                "" +
+                "@info(name='query4') " +
+                "from analyzeStream join timeWindow " +
+                "on analyzeStream.symbol == timeWindow.symbol " +
+                "select analyzeStream.symbol " +
+                "insert into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(cseEventStream + query);
+
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                count.addAndGet(events.length);
+                eventArrived = true;
+                for (Event event : events) {
+                    AssertJUnit.assertTrue(("IBM".equals(event.getData(0)) || "WSO2".equals(event.getData(0))));
+                }
+            }
+        });
+
+        InputHandler input = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        input.send(new Object[]{"IBM", 700});
+        input.send(new Object[]{"WSO2", 750});
+
+        SiddhiTestHelper.waitForEvents(100, 2, count, 4000);
+        AssertJUnit.assertEquals(2, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void delayWindowTest7() throws InterruptedException {
+        log.info("DelayWindow Test7: Testing persistence ");
+
+        PersistenceStore persistenceStore = new InMemoryPersistenceStore();
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setPersistenceStore(persistenceStore);
+
+        String cseEventStream = "" +
+                "define window delayWindow(symbol string, volume int) delay(1450);" +
+                "define stream inputStream(symbol string, volume int);" +
+                "define window timeWindow(symbol string) time(2 sec);";
+
+        String query = "" +
+                "@info(name='query1') " +
+                "from inputStream " +
+                "select symbol, volume " +
+                "insert into delayWindow; " +
+                "" +
+                "@info(name = 'query2') " +
+                "from delayWindow " +
+                "select symbol, sum(volume) as totalVolume " +
+                "insert into analyzeStream; " +
+                "" +
+                "@info(name='query3') " +
+                "from inputStream " +
+                "select symbol " +
+                "insert into timeWindow; " +
+                "" +
+                "@info(name='query4') " +
+                "from analyzeStream join timeWindow " +
+                "on analyzeStream.symbol == timeWindow.symbol " +
+                "select analyzeStream.symbol, analyzeStream.totalVolume " +
+                "insert into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(cseEventStream + query);
+
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                count.addAndGet(events.length);
+                for (Event event : events) {
+                    AssertJUnit.assertTrue(("IBM".equals(event.getData(0)) || "WSO2".equals(event.getData(0))));
+                }
+                lastValue = (Long) events[0].getData(1);
+            }
+        });
+
+        InputHandler input = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        input.send(new Object[]{"IBM", 700});
+        input.send(new Object[]{"WSO2", 750});
+
+        SiddhiTestHelper.waitForEvents(100, 2, count, 2100);
+
+        siddhiAppRuntime.persist();
+        siddhiAppRuntime.shutdown();
+
+        input = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
+
+        input.send(new Object[]{"WSO2", 600});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 2100);
+
+        AssertJUnit.assertEquals(Long.valueOf(2050), lastValue);
+        siddhiAppRuntime.shutdown();
+    }
+}


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add a new window feature to the siddhi stream processing. A siddhi developer may need to capture the events that has arrived and hold them for a specified time period before processing. In the current window implementations there is no direct implementation for this.

## Goals
This new window feature - delay window, will allow to process events received from streams after delaying them for defined time period.

## Approach
Implement new delay window processor class.

## User stories
A courier company wants to detect their non-delivered packages within a predefined period of time. Events arriving from arrival stream can be delayed and compared with the events from delivery stream to check the timely delivery of packages.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
    Class - 100%
    Method - 61%
    Line - 74%
   
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A
 
## Learning
N/A