### PR TITLE
Change delay window test cases waiting time

### DIFF
--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/DelayWindowTestCase.java
@@ -157,7 +157,7 @@ public class DelayWindowTestCase {
         input.send(new Object[]{"IBM", 800f, 0});
         input.send(new Object[]{"WSO2", 60.5f, 1});
 
-        SiddhiTestHelper.waitForEvents(100, 4, count, 2000);
+        SiddhiTestHelper.waitForEvents(100, 4, count, 4000);
         AssertJUnit.assertEquals(4, count.get());
         AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
@@ -203,7 +203,7 @@ public class DelayWindowTestCase {
             Thread.sleep(1100);
             cseEventStreamHandler.send(new Object[]{"WSO2", 57.6f, 100});
 
-            SiddhiTestHelper.waitForEvents(100, 2, count, 2000);
+            SiddhiTestHelper.waitForEvents(100, 2, count, 5000);
             AssertJUnit.assertEquals(2, count.get());
             AssertJUnit.assertTrue(eventArrived);
         } finally {
@@ -261,7 +261,7 @@ public class DelayWindowTestCase {
             inputHandler.send(new Object[]{1000});
             inputHandler.send(new Object[]{1500});
 
-            SiddhiTestHelper.waitForEvents(100, 2, count, 2000);
+            SiddhiTestHelper.waitForEvents(100, 2, count, 3000);
             AssertJUnit.assertEquals(2, inEventCount);
             AssertJUnit.assertEquals(0, removeEventCount);
             AssertJUnit.assertEquals(Long.valueOf(2500), lastValue);
@@ -327,7 +327,7 @@ public class DelayWindowTestCase {
         input.send(new Object[]{"IBM", 700});
         input.send(new Object[]{"WSO2", 750});
 
-        SiddhiTestHelper.waitForEvents(100, 2, count, 4000);
+        SiddhiTestHelper.waitForEvents(100, 2, count, 5000);
         AssertJUnit.assertEquals(2, count.get());
         AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
@@ -388,7 +388,7 @@ public class DelayWindowTestCase {
         input.send(new Object[]{"IBM", 700});
         input.send(new Object[]{"WSO2", 750});
 
-        SiddhiTestHelper.waitForEvents(100, 2, count, 2100);
+        SiddhiTestHelper.waitForEvents(100, 2, count, 4000);
 
         siddhiAppRuntime.persist();
         siddhiAppRuntime.shutdown();
@@ -403,7 +403,7 @@ public class DelayWindowTestCase {
         }
 
         input.send(new Object[]{"WSO2", 600});
-        SiddhiTestHelper.waitForEvents(100, 3, count, 2100);
+        SiddhiTestHelper.waitForEvents(100, 3, count, 4000);
 
         AssertJUnit.assertEquals(Long.valueOf(2050), lastValue);
         siddhiAppRuntime.shutdown();


### PR DESCRIPTION
## Purpose
This commit fix the delay window test case failing in Jenkins build. 

## Goals
N/A 

## Approach
Increase the waiting time for the events to be processed.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/siddhi/pull/926

## Migrations (if applicable)
N/A

## Learning
N/A