### PR TITLE
Add delay window in to documentation

### DIFF
--- a/docs/documentation/siddhi-4.0.md
+++ b/docs/documentation/siddhi-4.0.md
@@ -799,6 +799,7 @@ Following are some inbuilt windows shipped with Siddhi. For more window types, s
 * [cron](https://wso2.github.io/siddhi/api/latest/#cron-window)
 * [externalTime](https://wso2.github.io/siddhi/api/latest/#externaltime-window)
 * [externalTimeBatch](https://wso2.github.io/siddhi/api/latest/#externaltimebatch-window)
+* [delay](https://wso2.github.io/siddhi/api/latest/#delay-window)
 
 **Output event types**<a id="output-event-types" class='anchor' aria-hidden='true'></a> 
 


### PR DESCRIPTION
## Purpose
Add delay window in to documentation

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
