### PR TITLE
add session window behaviour

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/SessionComplexEventChunk.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/SessionComplexEventChunk.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.event;
+
+/**
+ * Collection used to manage session windows.
+ *
+ * @param <E> sub types of ComplexEvent such as StreamEvent and StateEvent.
+ */
+public class SessionComplexEventChunk<E extends ComplexEvent> extends ComplexEventChunk {
+
+    private String key;
+    private long startTimestamp;
+    private long endTimestamp;
+    private long aliveTimestamp;
+
+    public SessionComplexEventChunk(String key) {
+        super(false);
+        this.key = key;
+    }
+
+    public SessionComplexEventChunk() {
+        super(false);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    public long getEndTimestamp() {
+        return endTimestamp;
+    }
+
+    public void setEndTimestamp(long endTimestamp) {
+        this.endTimestamp = endTimestamp;
+    }
+
+    public long getAliveTimestamp() {
+        return aliveTimestamp;
+    }
+
+    public void setAliveTimestamp(long aliveTimestamp) {
+        this.aliveTimestamp = aliveTimestamp;
+    }
+
+    public void setTimestamps(long startTimestamp, long endTimestamp, long aliveTimestamp) {
+        this.startTimestamp = startTimestamp;
+        this.endTimestamp = endTimestamp;
+        this.aliveTimestamp = aliveTimestamp;
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/SessionWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/processor/stream/window/SessionWindowProcessor.java
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.query.processor.stream.window;
+
+import org.apache.log4j.Logger;
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.annotation.Parameter;
+import org.wso2.siddhi.annotation.util.DataType;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.event.ComplexEventChunk;
+import org.wso2.siddhi.core.event.SessionComplexEventChunk;
+import org.wso2.siddhi.core.event.state.StateEvent;
+import org.wso2.siddhi.core.event.stream.StreamEvent;
+import org.wso2.siddhi.core.event.stream.StreamEventCloner;
+import org.wso2.siddhi.core.executor.ConstantExpressionExecutor;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.executor.VariableExpressionExecutor;
+import org.wso2.siddhi.core.query.processor.Processor;
+import org.wso2.siddhi.core.query.processor.SchedulingProcessor;
+import org.wso2.siddhi.core.table.Table;
+import org.wso2.siddhi.core.util.Scheduler;
+import org.wso2.siddhi.core.util.SessionContainer;
+import org.wso2.siddhi.core.util.collection.operator.CompiledCondition;
+import org.wso2.siddhi.core.util.collection.operator.MatchingMetaInfoHolder;
+import org.wso2.siddhi.core.util.collection.operator.Operator;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.core.util.parser.OperatorParser;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
+import org.wso2.siddhi.query.api.expression.Expression;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Implementation of {@link WindowProcessor} which represent a Window operating based on a session.
+ */
+@Extension(
+        name = "session",
+        namespace = "",
+        description = "A session window that holds events into a session "
+                + "which has a grouping attribute (session key). After a session gap period, "
+                + "the session window would be expired. When a new event "
+                + "arrives with a value for session key, then it matches with a session window "
+                + "which has the same session key. A latency can be added to late arrival events "
+                + "to merge with the previous session windows. That latency time period "
+                + "should be less than the session gap time period. To have aggregate functions with session window, "
+                + "a 'group by' should be done with the session key. ",
+        parameters = {
+                @Parameter(name = "window.session",
+                        description = "The session gap time period(sec, min, ms).",
+                        type = {DataType.INT, DataType.LONG, DataType.TIME}),
+                @Parameter(name = "window.key",
+                        description = "The grouping attribute for events.",
+                        type = {DataType.STRING}, optional = true, defaultValue = "default-key"),
+                @Parameter(name = "window.allowedlatency",
+                        description = "This will allow to alive session window for a defined time period",
+                        type = {DataType.INT, DataType.LONG, DataType.TIME}, optional = true, defaultValue = "0")
+        },
+        examples = {
+                @Example(
+                        syntax = "define stream purchaseEventStream "
+                                + "(user string, item_number int, price float, quantity int);\n"
+                                + "\n"
+                                + "@info(name='query0) \n"
+                                + "from purchaseEventStream#window.session(5 sec, user, 2 sec) \n"
+                                + "select * \n"
+                                + "insert all events into outputStream;",
+                        description = "This will processing events that arrived from purchaseEvent stream "
+                                + "with the user name as the session key and the session gap 5 seconds. "
+                                + "It keeps the session window for 2 sec after session timeout."
+                )
+        }
+)
+public class SessionWindowProcessor extends WindowProcessor implements SchedulingProcessor, FindableProcessor {
+
+    private static final Logger log = Logger.getLogger(SessionWindowProcessor.class);
+
+    private long sessionGap = -1;
+    private long allowedLatency = -1;
+    private VariableExpressionExecutor sessionKeyExecutor;
+    private Scheduler scheduler;
+    private Map<String, SessionContainer> sessionMap;
+    private Map<String, Long> sessionKeyEndTimeMap;
+    private SessionContainer sessionContainer;
+    private SessionComplexEventChunk<StreamEvent> expiredEventChunk;
+
+    private static final String DEFAULT_KEY = "default-key";
+
+    @Override
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    @Override
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void init(ExpressionExecutor[] attributeExpressionExecutors,
+                        ConfigReader configReader, boolean outputExpectsExpiredEvents,
+                        SiddhiAppContext siddhiAppContext) {
+        this.sessionMap = new ConcurrentHashMap<>();
+        this.sessionKeyEndTimeMap = new HashMap<>();
+        this.sessionContainer = new SessionContainer();
+        this.expiredEventChunk = new SessionComplexEventChunk<>();
+
+        if (attributeExpressionExecutors.length >= 1 && attributeExpressionExecutors.length <= 3) {
+
+            if (attributeExpressionExecutors[0] instanceof ConstantExpressionExecutor) {
+                if (attributeExpressionExecutors[0].getReturnType() == Attribute.Type.INT ||
+                        attributeExpressionExecutors[0].getReturnType() == Attribute.Type.LONG) {
+                    sessionGap = (Long) ((ConstantExpressionExecutor) attributeExpressionExecutors[0]).getValue();
+                } else {
+                    throw new SiddhiAppValidationException("Session window's session gap parameter should be either "
+                            + "int or long, but found " + attributeExpressionExecutors[0].getReturnType());
+                }
+            } else {
+                throw new SiddhiAppValidationException("Session window's 1st parameter, session gap"
+                        + " should be a constant parameter attribute but "
+                        + "found a dynamic attribute " + attributeExpressionExecutors[0].getClass().getCanonicalName());
+            }
+            if (attributeExpressionExecutors.length == 3) {
+                if (attributeExpressionExecutors[1] instanceof VariableExpressionExecutor) {
+                    if (attributeExpressionExecutors[1].getReturnType() == Attribute.Type.STRING) {
+                        sessionKeyExecutor = (VariableExpressionExecutor) attributeExpressionExecutors[1];
+                    } else {
+                        throw new SiddhiAppValidationException("Session window's session key parameter type"
+                                + " should be string, but found " + attributeExpressionExecutors[1].getReturnType());
+                    }
+                } else {
+                    throw new SiddhiAppValidationException("Session window's 2nd parameter, session key"
+                            + " should be a dynamic parameter attribute but "
+                            + "found a constant attribute "
+                            + attributeExpressionExecutors[1].getClass().getCanonicalName());
+                }
+
+                if (attributeExpressionExecutors[2] instanceof ConstantExpressionExecutor) {
+                    if (attributeExpressionExecutors[2].getReturnType() == Attribute.Type.INT ||
+                            attributeExpressionExecutors[2].getReturnType() == Attribute.Type.LONG) {
+                        allowedLatency = (Long) ((ConstantExpressionExecutor)
+                                attributeExpressionExecutors[2]).getValue();
+                    } else {
+                        throw new SiddhiAppValidationException("Session window's allowedLatency parameter should be "
+                                + "either int or long, but found " + attributeExpressionExecutors[2].getReturnType());
+                    }
+                } else {
+                    throw new SiddhiAppValidationException("Session window's 3rd parameter, allowedLatency"
+                            + " should be a constant parameter attribute but "
+                            + "found a dynamic attribute "
+                            + attributeExpressionExecutors[2].getClass().getCanonicalName());
+                }
+            }
+
+            if (attributeExpressionExecutors.length == 2) {
+                if (attributeExpressionExecutors[1] instanceof VariableExpressionExecutor) {
+                    if (attributeExpressionExecutors[1].getReturnType() == Attribute.Type.STRING) {
+                        sessionKeyExecutor = (VariableExpressionExecutor) attributeExpressionExecutors[1];
+                    } else {
+                        throw new SiddhiAppValidationException("Session window's session key parameter type"
+                                + " should be string, but found " + attributeExpressionExecutors[1].getReturnType());
+                    }
+                } else {
+                    if (attributeExpressionExecutors[1].getReturnType() == Attribute.Type.INT ||
+                            attributeExpressionExecutors[1].getReturnType() == Attribute.Type.LONG) {
+                        allowedLatency = (Long) ((ConstantExpressionExecutor)
+                                attributeExpressionExecutors[1]).getValue();
+                    } else {
+                        throw new SiddhiAppValidationException("Session window's allowedLatency parameter should be "
+                                + "either int or long, but found " + attributeExpressionExecutors[1].getReturnType());
+                    }
+                }
+            }
+        } else {
+            throw new SiddhiAppValidationException("Session window should only have one to three parameters "
+                    + "(<int|long|time> sessionGap, <String> sessionKey, <int|long|time> allowedLatency, "
+                    + "but found " + attributeExpressionExecutors.length + " input attributes");
+
+        }
+
+        if (allowedLatency > sessionGap) {
+            throw new SiddhiAppValidationException("Session window's allowedLatency parameter value "
+                    + "should not be greater than the session gap parameter value");
+
+        }
+
+    }
+
+    @Override
+    protected void process(ComplexEventChunk<StreamEvent> streamEventChunk,
+                           Processor nextProcessor, StreamEventCloner streamEventCloner) {
+        String key;
+        SessionComplexEventChunk<StreamEvent> currentSession;
+
+        synchronized (this) {
+            while (streamEventChunk.hasNext()) {
+                StreamEvent streamEvent = streamEventChunk.next();
+                long eventTimestamp = streamEvent.getTimestamp();
+                long maxTimestamp = eventTimestamp + sessionGap;
+                long aliveTimestamp = maxTimestamp + allowedLatency;
+
+                if (streamEvent.getType() == StreamEvent.Type.CURRENT) {
+
+                    if (sessionKeyExecutor != null) {
+                        key = (String) sessionKeyExecutor.execute(streamEvent);
+                    } else {
+                        key = DEFAULT_KEY;
+                    }
+
+                    //get the session configuration based on session key
+                    //if the map doesn't contain key, then a new sessionContainer
+                    //object needs to be created.
+                    if (sessionMap.get(key) == null) {
+                        sessionContainer = new SessionContainer(key);
+                        sessionMap.put(key, sessionContainer);
+                    } else {
+                        sessionContainer = sessionMap.get(key);
+                    }
+
+                    StreamEvent clonedStreamEvent = streamEventCloner.copyStreamEvent(streamEvent);
+                    clonedStreamEvent.setType(StreamEvent.Type.EXPIRED);
+
+                    currentSession = sessionContainer.getCurrentSession();
+
+                    //if current session is empty
+                    if (sessionContainer.getCurrentSession().getFirst() == null) {
+                        currentSession.add(clonedStreamEvent);
+                        currentSession.setTimestamps(eventTimestamp, maxTimestamp, aliveTimestamp);
+                        scheduler.notifyAt(maxTimestamp);
+                    } else {
+                        if (eventTimestamp >= currentSession.getStartTimestamp()) {
+                            //check whether the event belongs to the same session
+                            if (eventTimestamp <= currentSession.getEndTimestamp()) {
+                                currentSession.setTimestamps(currentSession.getStartTimestamp(),
+                                        maxTimestamp, aliveTimestamp);
+                                currentSession.add(clonedStreamEvent);
+                                scheduler.notifyAt(maxTimestamp);
+                            } else {
+                                //when a new session starts
+                                if (allowedLatency > 0) {
+                                    moveCurrentSessionToPreviousSession();
+                                    currentSession.clear();
+                                    currentSession.setTimestamps(eventTimestamp, maxTimestamp, aliveTimestamp);
+                                    currentSession.add(clonedStreamEvent);
+                                    scheduler.notifyAt(maxTimestamp);
+                                }
+                            }
+
+                        } else {
+                            //when a late event arrives
+                           addLateEvent(streamEventChunk, eventTimestamp, clonedStreamEvent);
+                        }
+                    }
+                } else {
+                    currentSessionTimeout(eventTimestamp);
+                    if (allowedLatency > 0) {
+                        previousSessionTimeout(eventTimestamp);
+                    }
+                }
+            }
+        }
+
+        nextProcessor.process(streamEventChunk);
+
+        if (expiredEventChunk != null && expiredEventChunk.getFirst() != null) {
+            nextProcessor.process(expiredEventChunk);
+            expiredEventChunk.clear();
+        }
+    }
+
+    private void mergeWindows(SessionComplexEventChunk<StreamEvent> previousWindow,
+                              SessionComplexEventChunk<StreamEvent> nextWindow) {
+        //merge with the next window
+        if (previousWindow.getFirst() != null &&
+                previousWindow.getEndTimestamp() >= (nextWindow.getStartTimestamp() - sessionGap)) {
+
+            if (nextWindow.hasNext()) {
+                nextWindow.next();
+            }
+
+            nextWindow.insertBeforeCurrent(previousWindow.getFirst());
+            nextWindow.setStartTimestamp(previousWindow.getStartTimestamp());
+            previousWindow.clear();
+        }
+    }
+
+    private void moveCurrentSessionToPreviousSession() {
+
+        SessionComplexEventChunk<StreamEvent> currentSession = sessionContainer.getCurrentSession();
+        SessionComplexEventChunk<StreamEvent> previousSession = sessionContainer.getPreviousSession();
+
+        if (previousSession.getFirst() == null) {
+            previousSession.add(currentSession.getFirst());
+
+        } else {
+            expiredEventChunk.setKey(previousSession.getKey());
+            expiredEventChunk.setTimestamps(previousSession.getStartTimestamp(),
+                    previousSession.getEndTimestamp(), previousSession.getAliveTimestamp());
+            expiredEventChunk.add(previousSession.getFirst());
+
+            previousSession.clear();
+            previousSession.add(currentSession.getFirst());
+
+        }
+        previousSession.setTimestamps(currentSession.getStartTimestamp(),
+                currentSession.getEndTimestamp(),
+                currentSession.getAliveTimestamp());
+        scheduler.notifyAt(currentSession.getAliveTimestamp());
+
+    }
+
+    private void addLateEvent(ComplexEventChunk<StreamEvent> streamEventChunk,
+                              long eventTimestamp, StreamEvent streamEvent) {
+
+        SessionComplexEventChunk<StreamEvent> currentSession = sessionContainer.getCurrentSession();
+        SessionComplexEventChunk<StreamEvent> previousSession = sessionContainer.getPreviousSession();
+
+        if (allowedLatency > 0) {
+
+            if (eventTimestamp >= (currentSession.getStartTimestamp() - sessionGap)) {
+                if (currentSession.hasNext()) {
+                    currentSession.next();
+                }
+                currentSession.insertBeforeCurrent(streamEvent);
+                currentSession.setStartTimestamp(eventTimestamp);
+                mergeWindows(previousSession, currentSession);
+            } else {
+
+                if (previousSession.getFirst() == null &&
+                        eventTimestamp < (currentSession.getStartTimestamp() - sessionGap)) {
+                    streamEventChunk.remove();
+                    log.info("The event, " + streamEvent + " is late and it's session window has been timeout");
+
+                } else {
+                    if (eventTimestamp >= (previousSession.getStartTimestamp() - sessionGap)) {
+                        previousSession.add(streamEvent);
+                        //when this condition true, previous session will not merge with the current session
+                        if (eventTimestamp <= (previousSession.getEndTimestamp() - sessionGap) &&
+                                eventTimestamp < previousSession.getStartTimestamp()) {
+
+                            previousSession.setStartTimestamp(eventTimestamp);
+
+                        } else {
+                            previousSession.setEndTimestamp(eventTimestamp + sessionGap);
+                            previousSession.setAliveTimestamp(eventTimestamp + sessionGap + allowedLatency);
+                            mergeWindows(previousSession, currentSession);
+                        }
+
+                    } else {
+                        //late event does not belong to the previous session
+                        streamEventChunk.remove();
+                        log.info("The event, " + streamEvent + " is late and it's session window has been timeout");
+                    }
+                }
+            }
+        } else {
+            //no allowedLatency time
+            //check the late event belongs to the same session
+            if (eventTimestamp >= (currentSession.getStartTimestamp() - sessionGap)) {
+                if (currentSession.hasNext()) {
+                    currentSession.next();
+                }
+                currentSession.insertBeforeCurrent(streamEvent);
+                currentSession.setStartTimestamp(eventTimestamp);
+            } else {
+                streamEventChunk.remove();
+                log.info("The event, " + streamEvent + " is late and it's session window has been timeout");
+            }
+        }
+
+    }
+
+    private void currentSessionTimeout(long eventTimestamp) {
+        Map<String, Long> currentEndTimestamps = findAllCurrentEndTimestamps(sessionMap);
+
+        //sort on endTimestamps
+        if (currentEndTimestamps.size() > 1) {
+            currentEndTimestamps = currentEndTimestamps.entrySet().stream().sorted(Map.Entry.comparingByValue())
+                    .collect(toMap(e -> e.getKey(), e -> e.getValue(), (e1, e2) -> e1,
+                            LinkedHashMap::new));
+        }
+
+        for (Map.Entry<String, Long> entry : currentEndTimestamps.entrySet()) {
+            long sessionEndTime = entry.getValue();
+            SessionComplexEventChunk<StreamEvent> currentSession = sessionMap.get(entry.getKey())
+                    .getCurrentSession();
+            SessionComplexEventChunk<StreamEvent> previousSession = sessionMap.get(entry.getKey())
+                    .getPreviousSession();
+            if (currentSession.getFirst() != null && eventTimestamp >= sessionEndTime) {
+
+                if (allowedLatency > 0) {
+                    //move current session to previous session
+                    previousSession.add(currentSession.getFirst());
+                    previousSession.setTimestamps(currentSession.getStartTimestamp(),
+                            currentSession.getEndTimestamp(),
+                            currentSession.getAliveTimestamp());
+                    scheduler.notifyAt(currentSession.getAliveTimestamp());
+                    currentSession.clear();
+                } else {
+                    expiredEventChunk.setKey(currentSession.getKey());
+                    expiredEventChunk.setTimestamps(currentSession.getStartTimestamp(),
+                            currentSession.getEndTimestamp(),
+                            currentSession.getAliveTimestamp());
+                    expiredEventChunk.add(currentSession.getFirst());
+                    currentSession.clear();
+                }
+
+            } else {
+                break;
+            }
+        }
+    }
+
+    private void previousSessionTimeout(long eventTimestamp) {
+
+        Map<String, Long> previousEndTimestamps = findAllPreviousEndTimestamps(sessionMap);
+        SessionComplexEventChunk<StreamEvent> previousSession;
+
+        //sort on endTimestamps
+        if (previousEndTimestamps.size() > 1) {
+            previousEndTimestamps = previousEndTimestamps.entrySet().stream().sorted(Map.Entry.comparingByValue())
+                    .collect(toMap(e -> e.getKey(), e -> e.getValue(), (e1, e2) -> e1,
+                            LinkedHashMap::new));
+        }
+
+        for (Map.Entry<String, Long> entry : previousEndTimestamps.entrySet()) {
+            previousSession = sessionMap.get(entry.getKey()).getPreviousSession();
+
+            if (previousSession != null && previousSession.getFirst() != null &&
+                    eventTimestamp >= previousSession.getAliveTimestamp()) {
+
+                expiredEventChunk.setKey(previousSession.getKey());
+                expiredEventChunk.setTimestamps(previousSession.getStartTimestamp(),
+                        previousSession.getEndTimestamp(), previousSession.getAliveTimestamp());
+
+                expiredEventChunk.add(previousSession.getFirst());
+                previousSession.clear();
+            } else {
+                break;
+            }
+
+        }
+
+    }
+
+    private Map<String, Long> findAllCurrentEndTimestamps(Map<String, SessionContainer> sessionMap) {
+
+        Collection<SessionContainer> sessionContainerList =  sessionMap.values();
+
+        if (!sessionKeyEndTimeMap.isEmpty()) {
+            sessionKeyEndTimeMap.clear();
+        }
+
+        for (SessionContainer sessionContainer : sessionContainerList) {
+            //not getting empty session details
+            if (sessionContainer.getCurrentSessionEndTimestamp() != -1) {
+                sessionKeyEndTimeMap.put(sessionContainer.getKey(), sessionContainer.getCurrentSessionEndTimestamp());
+            }
+        }
+
+        return sessionKeyEndTimeMap;
+    }
+
+    private Map<String, Long> findAllPreviousEndTimestamps(Map<String, SessionContainer> sessionMap) {
+
+        Collection<SessionContainer> sessionContainerList =  sessionMap.values();
+
+        if (!sessionKeyEndTimeMap.isEmpty()) {
+            sessionKeyEndTimeMap.clear();
+        }
+
+        for (SessionContainer sessionContainer : sessionContainerList) {
+            //not getting empty session details
+            if (sessionContainer.getPreviousSessionEndTimestamp() != -1) {
+                sessionKeyEndTimeMap.put(sessionContainer.getKey(), sessionContainer.getPreviousSessionEndTimestamp());
+            }
+        }
+
+        return sessionKeyEndTimeMap;
+    }
+
+    @Override
+    public void start() {
+        //Do nothing
+    }
+
+    @Override
+    public void stop() {
+        //Do nothing
+    }
+
+    @Override
+    public synchronized Map<String, Object> currentState() {
+        Map<String, Object> state = new HashMap<>();
+        state.put("sessionMap", sessionMap);
+        state.put("sessionGap", sessionGap);
+        state.put("allowedLatency", allowedLatency);
+        state.put("sessionContainer", sessionContainer);
+        state.put("expiredEventChunk", expiredEventChunk);
+        return state;
+    }
+
+    @Override
+    public synchronized void restoreState(Map<String, Object> state) {
+        sessionMap = (ConcurrentHashMap<String, SessionContainer>) state.get("sessionMap");
+        sessionGap = (Long) state.get("sessionGap");
+        allowedLatency = (Long) state.get("allowedLatency");
+        sessionContainer = (SessionContainer) state.get("sessionContainer");
+        expiredEventChunk = (SessionComplexEventChunk<StreamEvent>) state.get("expiredEventChunk");
+    }
+
+    @Override
+    public synchronized StreamEvent find(StateEvent matchingEvent, CompiledCondition compiledCondition) {
+        return ((Operator) compiledCondition).find(matchingEvent, expiredEventChunk, streamEventCloner);
+    }
+
+    @Override
+    public CompiledCondition compileCondition(Expression condition, MatchingMetaInfoHolder matchingMetaInfoHolder,
+                                              SiddhiAppContext siddhiAppContext,
+                                              List<VariableExpressionExecutor> variableExpressionExecutors,
+                                              Map<String, Table> tableMap, String queryName) {
+        return OperatorParser.constructOperator(expiredEventChunk, condition, matchingMetaInfoHolder,
+                siddhiAppContext, variableExpressionExecutors, tableMap, this.queryName);
+
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SessionContainer.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SessionContainer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.util;
+
+import org.wso2.siddhi.core.event.SessionComplexEventChunk;
+import org.wso2.siddhi.core.event.stream.StreamEvent;
+
+import java.io.Serializable;
+
+/**
+ * This keeps the information of a session key. i.e. current session and the previous session
+ */
+public class SessionContainer implements Serializable {
+
+    private String key;
+    private SessionComplexEventChunk<StreamEvent> currentSession;
+    private SessionComplexEventChunk<StreamEvent> previousSession;
+
+    public SessionContainer(String key) {
+        currentSession = new SessionComplexEventChunk<>(key);
+        previousSession = new SessionComplexEventChunk<>(key);
+        this.key = key;
+    }
+
+    public SessionContainer() {
+        currentSession = new SessionComplexEventChunk<>();
+        previousSession = new SessionComplexEventChunk<>();
+    }
+
+    public long getCurrentSessionEndTimestamp() {
+        if (currentSession.getFirst() != null) {
+            return currentSession.getEndTimestamp();
+        } else {
+            return -1;
+        }
+    }
+
+    public long getPreviousSessionEndTimestamp() {
+        if (previousSession.getFirst() != null) {
+            return previousSession.getEndTimestamp();
+        } else {
+            return -1;
+        }
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public SessionComplexEventChunk<StreamEvent> getCurrentSession() {
+        return currentSession;
+    }
+
+    public SessionComplexEventChunk<StreamEvent> getPreviousSession() {
+        return previousSession;
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/SessionWindowTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/window/SessionWindowTestCase.java
@@ -1,0 +1,1065 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.window;
+
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.UnitTestAppender;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.query.processor.stream.window.SessionWindowProcessor;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.stream.output.StreamCallback;
+import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.core.util.SiddhiTestHelper;
+import org.wso2.siddhi.core.util.persistence.InMemoryPersistenceStore;
+import org.wso2.siddhi.core.util.persistence.PersistenceStore;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Session window test case implementation.
+ */
+public class SessionWindowTestCase {
+
+    private static final Logger log = Logger.getLogger(SessionWindowTestCase.class);
+    private int inEventCount;
+    private int removeEventCount;
+    private boolean eventArrived;
+    private boolean innerAssertionsPassed;
+    private AtomicInteger count = new AtomicInteger(0);
+    private long eventTimeStamp;
+    private double averageValue;
+    private double totalValue;
+
+    @BeforeMethod
+    public void init() {
+        inEventCount = 0;
+        removeEventCount = 0;
+        eventArrived = false;
+        innerAssertionsPassed = false;
+        eventTimeStamp = 0;
+        count.set(0);
+        averageValue = Double.valueOf(0);
+        totalValue = Double.valueOf(0);
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails when more than three parameters are provided'",
+            expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow1() {
+        log.info("SessionWindow Test1: Testing session window with more than defined parameters");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, user, 2 sec, 1) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window should only have one to three parameters "
+                    + "(<int|long|time> sessionGap, <String> sessionKey, <int|long|time> allowedLatency, "
+                    + "but found 4 input attributes", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails when session gap parameter is dynamic",
+            expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow2() {
+        log.info("SessionWindow Test2: Testing session window with providing session gap parameter as a dynamic one");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(item_number, user, 2 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's 1st parameter, session gap should be a constant parameter"
+                    + " attribute but found a dynamic attribute "
+                    + "org.wso2.siddhi.core.executor.VariableExpressionExecutor", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails "
+            + "when session gap parameter with wrong data type ", expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow3() {
+        log.info("SessionWindow Test3: Testing session window "
+                + "with providing wrong data type for session gap parameter ");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session('3', user, 2 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's session gap parameter should be either "
+                    + "int or long, but found STRING", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails "
+            + "when session key parameter with a constant value", expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow4() {
+        log.info("SessionWindow Test4: Testing session window "
+                + "with providing a constant value for session key parameter ");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, 'user', 2 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's 2nd parameter, session key should be a dynamic parameter"
+                    + " attribute but found a constant attribute "
+                    + "org.wso2.siddhi.core.executor.ConstantExpressionExecutor", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails "
+            + "when session key parameter with wrong data type", expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow5() {
+        log.info("SessionWindow Test5: Testing session window "
+                + "with defining wrong data type for session key parameter ");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, item_number, 2 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's session key parameter type "
+                    + "should be string, but found INT", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails when"
+            + " allowedLatency parameter with a dynamic value", expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow6() {
+        log.info("SessionWindow Test6: Testing session window "
+                + "with providing dynamic value for allowedLatency");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, user, item_number) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's 3rd parameter, allowedLatency should be a "
+                    + "constant parameter attribute but found a dynamic attribute "
+                    + "org.wso2.siddhi.core.executor.VariableExpressionExecutor", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails when"
+            + " allowedLatency parameter with a wrong data type", expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow7() {
+        log.info("SessionWindow Test7: Testing session window "
+                + "with providing wrong data type for allowedLatency");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, user, '4') "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's allowedLatency parameter should be "
+                    + "either int or long, but found STRING", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails when"
+            + " provided 2 paramters and 2nd parameter with wrong data type",
+            expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow8() {
+        log.info("SessionWindow Test8: Testing session window "
+                + "with providing 2 parameters and 2nd parameter type is wrong");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, item_number) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's session key parameter type should be string, "
+                    + "but found INT", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks if Siddhi App creation fails when"
+            + " provided 2 paramters and 2nd parameter allowedLatency with wrong data type",
+            expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow9() {
+        log.info("SessionWindow Test9: Testing session window "
+                + "with providing 2 parameters and 2nd parameter allowedLatency type is wrong");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, '5') "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's allowedLatency parameter should be either int or long,"
+                    + " but found STRING", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test checks whether the allowedLatency parameter value is greater"
+            + " than the session gap value", expectedExceptions = SiddhiAppCreationException.class)
+    public void testSessionWindow10() {
+        log.info("SessionWindow Test10: Testing session window "
+                + "with providing greater allowedLatency value than session gap value");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = null;
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int);";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(5 sec, 6 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+        try {
+            siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        } catch (SiddhiAppCreationException e) {
+            AssertJUnit.assertEquals("Session window's allowedLatency parameter value should not be greater than "
+                    + "the session gap parameter value", e.getCause().getMessage());
+            throw e;
+        } finally {
+            if (siddhiAppRuntime != null) {
+                siddhiAppRuntime.shutdown();
+            }
+
+        }
+    }
+
+    @Test(description = "This test case checks an event initiate a session and wait for session timeout")
+    public void testSessionWindow11() throws InterruptedException {
+        log.info("SessionWindow Test11: Testing session window with an input event");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(1 sec, user) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+                }
+
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 2) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(101, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        inputHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send(new Object[]{"user0", 102, 24.6, 2});
+
+        SiddhiTestHelper.waitForEvents(100, 4, count, 4000);
+        AssertJUnit.assertEquals(2, inEventCount);
+        AssertJUnit.assertEquals(2, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "This test case checks two sessions are processed which  belong to the same session key")
+    public void testSessionWindow12() throws InterruptedException {
+        log.info("SessionWindow Test12: Testing session window, providing events "
+                + "which are in 2 session with same session key");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(1 sec, user) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 2) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(101, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    } else if (removeEventCount == 4) {
+                        innerAssertionsPassed = false;
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(103, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(104, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        inputHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send(new Object[]{"user0", 102, 24.5, 2});
+        Thread.sleep(1100);
+
+        inputHandler.send(new Object[]{"user0", 103, 22.4, 1});
+        inputHandler.send(new Object[]{"user0", 104, 50.0, 3});
+
+        SiddhiTestHelper.waitForEvents(100, 8, count, 4200);
+        AssertJUnit.assertEquals(4, inEventCount);
+        AssertJUnit.assertEquals(4, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "This test case checks two sessions are created and processed"
+            + " which belong to different session keys")
+    public void testSessionWindow13() throws InterruptedException {
+        log.info("SessionWindow Test13: Testing session window, providing events "
+                + "which are in 2 session with different session keys");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(1 sec, user) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 2) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(101, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    } else if (removeEventCount == 4) {
+                        innerAssertionsPassed = false;
+                        AssertJUnit.assertTrue("user1".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user1".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(103, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(104, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        inputHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send(new Object[]{"user0", 102, 24.5, 2});
+        Thread.sleep(10);
+        inputHandler.send(new Object[]{"user1", 103, 22.4, 1});
+        inputHandler.send(new Object[]{"user1", 104, 50.0, 3});
+
+        SiddhiTestHelper.waitForEvents(100, 8, count, 4200);
+        AssertJUnit.assertEquals(4, inEventCount);
+        AssertJUnit.assertEquals(4, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "This test case checks two sessions are created and processed after the allowedLatency")
+    public void testSessionWindow14() throws InterruptedException {
+        log.info("SessionWindow Test14: Testing session window, "
+                + "two sessions are created and processed after the allowedLatency");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(2 sec, user, 1 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 2) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(101, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    } else if (removeEventCount == 4) {
+                        innerAssertionsPassed = false;
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(103, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(104, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        inputHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send(new Object[]{"user0", 102, 24.5, 2});
+        Thread.sleep(2005);
+
+        inputHandler.send(new Object[]{"user0", 103, 22.4, 1});
+        inputHandler.send(new Object[]{"user0", 104, 50.0, 3});
+
+        SiddhiTestHelper.waitForEvents(100, 8, count, 5200);
+        AssertJUnit.assertEquals(4, inEventCount);
+        AssertJUnit.assertEquals(4, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "This test case checks when the late event which is "
+            + "belong to the current session window without an allowedLatency")
+    public void testSessionWindow15() throws InterruptedException {
+        log.info("SessionWindow Test15: Testing session window, "
+                + "late event comes which belong to the current session window without an allowedLatency time period");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(2 sec, user) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 3) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[2].getData(0)));
+
+                        AssertJUnit.assertEquals(103, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(101, removeEvents[1].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[2].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        eventTimeStamp = System.currentTimeMillis();
+        inputHandler.send(eventTimeStamp, new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send((eventTimeStamp + 10), new Object[]{"user0", 102, 24.5, 2});
+        //late event
+        inputHandler.send((eventTimeStamp - 1000), new Object[]{"user0", 103, 24.5, 2});
+
+        SiddhiTestHelper.waitForEvents(100, 6, count, 4100);
+        AssertJUnit.assertEquals(3, inEventCount);
+        AssertJUnit.assertEquals(3, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "This test case checks with the late event which "
+            + "does not belong to the current session without an allowedLatency time period")
+    public void testSessionWindow16() throws InterruptedException {
+        log.info("SessionWindow Test16: Testing session window, "
+                + "late event which does not belong to the current "
+                +  "session window without an allowedLatency time period");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        Logger logger = Logger.getLogger(SessionWindowProcessor.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        logger.addAppender(appender);
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(2 sec, user) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 2) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+
+                        AssertJUnit.assertEquals(101, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[1].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        eventTimeStamp = System.currentTimeMillis();
+        inputHandler.send(eventTimeStamp, new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send((eventTimeStamp + 10), new Object[]{"user0", 102, 24.5, 2});
+        //late event
+        inputHandler.send((eventTimeStamp - 2500), new Object[]{"user0", 103, 24.5, 2});
+
+        AssertJUnit.assertTrue(appender.getMessages().contains("[user0, 103, 24.5, 2]"));
+        SiddhiTestHelper.waitForEvents(100, 4, count, 4100);
+        AssertJUnit.assertEquals(2, inEventCount);
+        AssertJUnit.assertEquals(2, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "This test case covers when a late event belongs "
+            + "to the current session and other belongs to the previous session and the other "
+            + "does not belong to the previous session with allowedLatency time period")
+    public void testSessionWindow17() throws InterruptedException {
+        log.info("SessionWindow Test17: Testing session window, "
+                + "three late events are coming, one belongs to the current session"
+                + "and the another belongs to the previous session and the other "
+                + "does not belong to the previous session");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        Logger logger = Logger.getLogger(SessionWindowProcessor.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        logger.addAppender(appender);
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(2 sec, user, 1 sec) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                    if (removeEventCount == 6) {
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[0].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[1].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[2].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[3].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[4].getData(0)));
+                        AssertJUnit.assertTrue("user0".equals(removeEvents[5].getData(0)));
+
+                        AssertJUnit.assertEquals(104, removeEvents[0].getData(1));
+                        AssertJUnit.assertEquals(101, removeEvents[1].getData(1));
+                        AssertJUnit.assertEquals(102, removeEvents[2].getData(1));
+                        AssertJUnit.assertEquals(105, removeEvents[3].getData(1));
+                        AssertJUnit.assertEquals(103, removeEvents[4].getData(1));
+                        AssertJUnit.assertEquals(106, removeEvents[5].getData(1));
+                        innerAssertionsPassed = true;
+                    }
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        eventTimeStamp = System.currentTimeMillis();
+        inputHandler.send(eventTimeStamp, new Object[]{"user0", 101, 34.4, 5});
+        inputHandler.send((eventTimeStamp + 10), new Object[]{"user0", 102, 24.5, 2});
+        Thread.sleep(2020);
+
+        eventTimeStamp = System.currentTimeMillis();
+        inputHandler.send(eventTimeStamp, new Object[]{"user0", 103, 24.5, 2});
+        inputHandler.send((eventTimeStamp - 100), new Object[]{"user0", 104, 54.5, 12});
+
+        inputHandler.send((eventTimeStamp - 2500), new Object[]{"user0", 105, 24.5, 6});
+        inputHandler.send((eventTimeStamp - 2400), new Object[]{"user0", 106, 24.5, 2});
+        //this late event later than the previous session
+        inputHandler.send((eventTimeStamp - 5200), new Object[]{"user0", 107, 24.5, 2});
+        AssertJUnit.assertTrue(appender.getMessages().contains("[user0, 107, 24.5, 2]"));
+
+        SiddhiTestHelper.waitForEvents(100, 10, count, 5200);
+        AssertJUnit.assertEquals(6, inEventCount);
+        AssertJUnit.assertEquals(6, removeEventCount);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "Check if events are persist when using session window")
+    public void testSessionWindow18() throws InterruptedException {
+        log.info("SessionWindow Test18: Testing persistence ");
+
+        PersistenceStore persistenceStore = new InMemoryPersistenceStore();
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setPersistenceStore(persistenceStore);
+
+        String purchaseEventStream = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(2 sec, user) "
+                + "select * "
+                + "insert all events into outputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(purchaseEventStream + query);
+
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                count.addAndGet(events.length);
+                for (Event event : events) {
+                    innerAssertionsPassed = false;
+                    AssertJUnit.assertTrue(("101".equals(event.getData(1).toString()) ||
+                            "102".equals(event.getData(1).toString())) ||
+                            "103".equals(event.getData(1).toString()));
+                    innerAssertionsPassed = true;
+                }
+
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        inputHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        Thread.sleep(100);
+        inputHandler.send(new Object[]{"user0", 102, 24.5, 2});
+
+        siddhiAppRuntime.persist();
+        siddhiAppRuntime.shutdown();
+
+        inputHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        try {
+            siddhiAppRuntime.restoreLastRevision();
+        } catch (CannotRestoreSiddhiAppStateException e) {
+            Assert.fail("Restoring of Siddhi app " + siddhiAppRuntime.getName() + " failed");
+        }
+        inputHandler.send(new Object[]{"user0", 103, 24.5, 2});
+
+        SiddhiTestHelper.waitForEvents(100, 3, count, 4200);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+
+    @Test(description = "Check whether joins are working with session window")
+    public void testSessionWindow19() throws InterruptedException {
+        log.info("SessionWindow Test19: testing joins");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = ""
+                + "define stream purchaseEventStream (user string, item_number int, price float, quantity int); "
+                + "define stream twitterStream (user string, tweet string); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(1 sec, user) "
+                + "join twitterStream#window.length(2) "
+                + "on purchaseEventStream.user == twitterStream.user "
+                + "select purchaseEventStream.user, twitterStream.tweet, "
+                + "purchaseEventStream.price, purchaseEventStream.quantity "
+                + "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                if (events != null) {
+                    count.addAndGet(events.length);
+                }
+                AssertJUnit.assertTrue(events[0].toString().contains("user0, Hello Tweet 1, 34.4, 5") ||
+                        events[0].toString().contains("user1, Hello Tweet 2, 24.5, 12") ||
+                        events[0].toString().contains("user1, Hello Tweet 2, 44.5, 12"));
+                eventArrived = true;
+                innerAssertionsPassed = true;
+            }
+        });
+
+        InputHandler purchaseEventStreamHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        InputHandler twitterStreamHandler = siddhiAppRuntime.getInputHandler("twitterStream");
+        siddhiAppRuntime.start();
+
+        purchaseEventStreamHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        purchaseEventStreamHandler.send(new Object[]{"user1", 102, 24.5, 12});
+        purchaseEventStreamHandler.send(new Object[]{"user1", 102, 44.5, 12});
+
+        twitterStreamHandler.send(new Object[]{"user0", "Hello Tweet 1"});
+        twitterStreamHandler.send(new Object[]{"user1", "Hello Tweet 2"});
+
+        SiddhiTestHelper.waitForEvents(100, 10, count, 4200);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(description = "Check whether aggregations are done correctly with session window")
+    public void testSessionWindow20() throws InterruptedException {
+        log.info("SessionWindow Test20: testing aggregations");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = ""
+                + "define stream purchaseEventStream (user string, item_number int, price double, quantity int); ";
+
+        String query = ""
+                + "@info(name = 'query0') "
+                + "from purchaseEventStream#window.session(1 sec, user) "
+                + "select user, avg(price) as avgPrice, sum(price) as totPrice group by user "
+                + "insert into outputStream;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        siddhiAppRuntime.addCallback("query0", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    inEventCount = inEventCount + inEvents.length;
+                    count.addAndGet(inEvents.length);
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                    count.addAndGet(removeEvents.length);
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        StreamCallback callBack = new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                for (Event event : events) {
+                    innerAssertionsPassed = false;
+                    averageValue = (Double) event.getData(1);
+                    totalValue = (Double) event.getData(2);
+                    innerAssertionsPassed = true;
+                }
+            }
+        };
+
+        siddhiAppRuntime.addCallback("outputStream", callBack);
+
+        InputHandler purchaseEventStreamHandler = siddhiAppRuntime.getInputHandler("purchaseEventStream");
+        siddhiAppRuntime.start();
+
+        purchaseEventStreamHandler.send(new Object[]{"user0", 101, 34.4, 5});
+        purchaseEventStreamHandler.send(new Object[]{"user0", 102, 24.5, 2});
+
+        purchaseEventStreamHandler.send(new Object[]{"user1", 101, 5.0, 5});
+        purchaseEventStreamHandler.send(new Object[]{"user1", 102, 6.0, 2});
+
+        SiddhiTestHelper.waitForEvents(100, 2, count, 4200);
+        AssertJUnit.assertEquals(4, inEventCount);
+        AssertJUnit.assertEquals(0, removeEventCount);
+        AssertJUnit.assertTrue(Double.valueOf(29.45) == averageValue || Double.valueOf(5.5) == averageValue);
+        AssertJUnit.assertTrue(Double.valueOf(58.9) == totalValue || Double.valueOf(11.0) == totalValue);
+        AssertJUnit.assertTrue(eventArrived);
+        AssertJUnit.assertTrue(innerAssertionsPassed);
+        siddhiAppRuntime.shutdown();
+    }
+
+}


### PR DESCRIPTION
## Purpose
The purpose is to add the  session window  behaviour to the  Siddhi Stream Processor. As a sample scenario, a siddhi developer may need to capture the number of purchased items per session.

## Goals
The new feature - session window, will process the events of sessions

## Approach
- Implement a SessionComplexEventChunk class which has session start time and end time
- Implement a SessionContainer class which store the session information for a particular session key
- Implement a new process window called SessionWindowProcessor

## User stories
A marketing company may wants to capture the number of click events (interactions with the website) per user sessions.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   Class - 100%
   Method - 94%
   Line - 84%

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Learning
N/A