### PR TITLE
Add metrics levels to Siddhi

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -85,6 +85,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Keep streamDefinitions, partitionRuntimes, queryRuntimes of an SiddhiApp and streamJunctions and inputHandlers used.
  */
@@ -162,7 +164,7 @@ public class SiddhiAppRuntime {
             monitorQueryMemoryUsage();
             monitorBufferedEvents();
             storeQueryLatencyTracker = QueryParserHelper.createLatencyTracker(siddhiAppContext, "query",
-                    SiddhiConstants.METRIC_INFIX_STORE_QUERIES, null);
+                    SiddhiConstants.METRIC_INFIX_STORE_QUERIES, null, INFO);
         }
 
         for (Map.Entry<String, List<Sink>> sinkEntries : sinkMap.entrySet()) {
@@ -663,7 +665,7 @@ public class SiddhiAppRuntime {
                 .getSiddhiContext()
                 .getStatisticsConfiguration()
                 .getFactory()
-                .createMemoryUsageTracker(siddhiAppContext.getStatisticsManager());
+                .createMemoryUsageTracker(siddhiAppContext.getStatisticsManager(), INFO);
         for (Map.Entry<String, QueryRuntime> entry : queryProcessorMap.entrySet()) {
             QueryParserHelper.registerMemoryUsageTracking(entry.getKey(), entry.getValue(),
                     SiddhiConstants.METRIC_INFIX_QUERIES, siddhiAppContext, memoryUsageTracker);
@@ -690,7 +692,7 @@ public class SiddhiAppRuntime {
                 .getSiddhiContext()
                 .getStatisticsConfiguration()
                 .getFactory()
-                .createBufferSizeTracker(siddhiAppContext.getStatisticsManager());
+                .createBufferSizeTracker(siddhiAppContext.getStatisticsManager(), INFO);
         for (Map.Entry<String, StreamJunction> entry : streamJunctionMap.entrySet()) {
             registerForBufferedEvents(entry);
         }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/StreamJunction.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/StreamJunction.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Stream Junction is the place where streams are collected and distributed. There will be an Stream Junction per
  * evey event stream. {@link StreamJunction.Publisher} can be used to publish events to the junction and
@@ -80,7 +82,7 @@ public class StreamJunction implements EventBufferHolder {
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     streamDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_STREAMS, null);
+                    SiddhiConstants.METRIC_INFIX_STREAMS, null, INFO);
         }
         try {
             Annotation annotation = AnnotationHelper.getAnnotation(SiddhiConstants.ANNOTATION_ASYNC,

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceMapper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceMapper.java
@@ -31,6 +31,8 @@ import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
 import java.util.List;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Convert custom input from {@link Source} to {@link org.wso2.siddhi.core.event.ComplexEventChunk}.
  */
@@ -66,11 +68,11 @@ public abstract class SourceMapper implements SourceEventListener {
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     streamDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_SOURCES, sourceType);
+                    SiddhiConstants.METRIC_INFIX_SOURCES, sourceType, INFO);
             this.mapperLatencyTracker = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                     streamDefinition.getId(),
                     SiddhiConstants.METRIC_INFIX_SOURCE_MAPPERS,
-                    sourceType + SiddhiConstants.METRIC_DELIMITER + mapType);
+                    sourceType + SiddhiConstants.METRIC_DELIMITER + mapType, INFO);
         }
         init(streamDefinition, mapOptionHolder, attributeMappings, configReader, siddhiAppContext);
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/Sink.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/output/sink/Sink.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * This is a Sink type. these let users to publish events according to
  * some type. this type can either be local, jms or ws (or any custom extension)
@@ -73,11 +75,11 @@ public abstract class Sink implements SinkListener, Snapshotable {
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     streamDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_SINKS, type);
+                    SiddhiConstants.METRIC_INFIX_SINKS, type, INFO);
             this.mapperLatencyTracker = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                     streamDefinition.getId(),
                     SiddhiConstants.METRIC_INFIX_SINK_MAPPERS,
-                    type + SiddhiConstants.METRIC_DELIMITER + mapType);
+                    type + SiddhiConstants.METRIC_DELIMITER + mapType, INFO);
         }
         init(streamDefinition, transportOptionHolder, sinkConfigReader, siddhiAppContext);
         if (sinkMapper != null) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/Table.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/table/Table.java
@@ -50,6 +50,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Interface class to represent Tables in Siddhi. There are multiple implementations. Ex: {@link InMemoryTable}. Table
  * will support basic operations of add, delete, update, update or add and contains. *
@@ -89,33 +91,36 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         this.recordTableHandler = recordTableHandler;
         if (siddhiAppContext.getStatisticsManager() != null) {
             latencyTrackerFind = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND, INFO);
             latencyTrackerInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT, INFO);
             latencyTrackerUpdate = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE, INFO);
             latencyTrackerDelete = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE, INFO);
             latencyTrackerUpdateOrInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                     tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES,
-                    SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT);
+                    SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT, INFO);
             latencyTrackerContains = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS, INFO);
 
             throughputTrackerFind = QueryParserHelper.createThroughputTracker(siddhiAppContext, tableDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND, INFO);
             throughputTrackerInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT,
+                    INFO);
             throughputTrackerUpdate = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE,
+                    INFO);
             throughputTrackerDelete = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE,
+                    INFO);
             throughputTrackerUpdateOrInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES,
-                    SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT);
+                    SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT, INFO);
             throughputTrackerContains = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS);
-
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS,
+                    INFO);
 
         }
         init(tableDefinition, storeEventPool, storeEventCloner, configReader, siddhiAppContext, recordTableHandler);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/trigger/CronTrigger.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/trigger/CronTrigger.java
@@ -39,6 +39,8 @@ import org.wso2.siddhi.core.util.parser.helper.QueryParserHelper;
 import org.wso2.siddhi.core.util.statistics.ThroughputTracker;
 import org.wso2.siddhi.query.api.definition.TriggerDefinition;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Implementation of {@link Trigger} which will trigger events based on a cron expression.
  */
@@ -63,7 +65,7 @@ public class CronTrigger implements Trigger, Job {
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     triggerDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TRIGGERS, null);
+                    SiddhiConstants.METRIC_INFIX_TRIGGERS, null, INFO);
         }
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/trigger/PeriodicTrigger.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/trigger/PeriodicTrigger.java
@@ -29,6 +29,8 @@ import org.wso2.siddhi.query.api.definition.TriggerDefinition;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Implementation of {@link Trigger} which will trigger events based on a pre-defined period.
  */
@@ -48,7 +50,7 @@ public class PeriodicTrigger implements Trigger {
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     triggerDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TRIGGERS, null);
+                    SiddhiConstants.METRIC_INFIX_TRIGGERS, null, INFO);
         }
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/trigger/StartTrigger.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/trigger/StartTrigger.java
@@ -26,6 +26,8 @@ import org.wso2.siddhi.core.util.parser.helper.QueryParserHelper;
 import org.wso2.siddhi.core.util.statistics.ThroughputTracker;
 import org.wso2.siddhi.query.api.definition.TriggerDefinition;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Implementation of {@link Trigger} which will trigger events when siddhi app in started.
  */
@@ -44,7 +46,7 @@ public class StartTrigger implements Trigger {
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     triggerDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_TRIGGERS, null);
+                    SiddhiConstants.METRIC_INFIX_TRIGGERS, null, INFO);
         }
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
@@ -45,6 +45,7 @@ import org.wso2.siddhi.core.util.extension.holder.IncrementalAttributeAggregator
 import org.wso2.siddhi.core.util.lock.LockWrapper;
 import org.wso2.siddhi.core.util.parser.helper.QueryParserHelper;
 import org.wso2.siddhi.core.util.statistics.LatencyTracker;
+import org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory;
 import org.wso2.siddhi.core.util.statistics.ThroughputTracker;
 import org.wso2.siddhi.core.window.Window;
 import org.wso2.siddhi.query.api.aggregation.TimePeriod;
@@ -70,6 +71,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
 
 /**
  * This is the parser class of incremental aggregation definition.
@@ -296,17 +299,17 @@ public class AggregationParser {
             if (siddhiAppContext.getStatisticsManager() != null) {
                 latencyTrackerFind = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND);
+                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND, INFO);
                 latencyTrackerInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT);
+                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT, INFO);
 
                 throughputTrackerFind = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND);
+                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND, INFO);
                 throughputTrackerInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT);
+                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT, INFO);
             }
 
             List<ExpressionExecutor> baseExecutors = cloneExpressionExecutors(processExpressionExecutorsList.get(0));

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/QueryParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/QueryParser.java
@@ -40,6 +40,7 @@ import org.wso2.siddhi.core.util.lock.LockSynchronizer;
 import org.wso2.siddhi.core.util.lock.LockWrapper;
 import org.wso2.siddhi.core.util.parser.helper.QueryParserHelper;
 import org.wso2.siddhi.core.util.statistics.LatencyTracker;
+import org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory;
 import org.wso2.siddhi.core.window.Window;
 import org.wso2.siddhi.query.api.annotation.Element;
 import org.wso2.siddhi.query.api.definition.AbstractDefinition;
@@ -54,8 +55,9 @@ import org.wso2.siddhi.query.api.util.AnnotationHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
 
 /**
  * Class to parse {@link QueryRuntime}.
@@ -102,7 +104,7 @@ public class QueryParser {
                 queryName = "query_" + queryIndex;
             }
             latencyTracker = QueryParserHelper.createLatencyTracker(siddhiAppContext, queryName,
-                    SiddhiConstants.METRIC_INFIX_QUERIES, null);
+                    SiddhiConstants.METRIC_INFIX_QUERIES, null, INFO);
             OutputStream.OutputEventType outputEventType = query.getOutputStream().getOutputEventType();
             boolean outputExpectsExpiredEvents = false;
             if (outputEventType != OutputStream.OutputEventType.CURRENT_EVENTS) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
@@ -117,7 +117,7 @@ public class SiddhiAppParser {
                         .createStatisticsManager(
                                 siddhiContext.getStatisticsConfiguration().getMetricPrefix(),
                                 siddhiAppContext.getName(),
-                                statisticsElements));
+                                statisticsElements, true));
             }
 
             Element statStateEnableElement = AnnotationHelper.getAnnotationElement(

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
@@ -43,6 +43,7 @@ import org.wso2.siddhi.core.util.collection.operator.IncrementalAggregateCompile
 import org.wso2.siddhi.core.util.lock.LockWrapper;
 import org.wso2.siddhi.core.util.statistics.LatencyTracker;
 import org.wso2.siddhi.core.util.statistics.MemoryUsageTracker;
+import org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory;
 import org.wso2.siddhi.core.util.statistics.ThroughputTracker;
 import org.wso2.siddhi.query.api.definition.Attribute;
 
@@ -224,7 +225,8 @@ public class QueryParserHelper {
     }
 
     public static LatencyTracker createLatencyTracker(SiddhiAppContext siddhiAppContext, String name, String type,
-                                                      String function) {
+                                                      String function,
+                                                      StatisticsTrackerFactory.MetricsLogLevel metricsLogLevel) {
         LatencyTracker latencyTracker = null;
         if (siddhiAppContext.getStatisticsManager() != null) {
             String metricName =
@@ -249,14 +251,15 @@ public class QueryParserHelper {
                 latencyTracker = siddhiAppContext.getSiddhiContext()
                         .getStatisticsConfiguration()
                         .getFactory()
-                        .createLatencyTracker(metricName, siddhiAppContext.getStatisticsManager());
+                        .createLatencyTracker(metricName, siddhiAppContext.getStatisticsManager(), metricsLogLevel);
             }
         }
         return latencyTracker;
     }
 
     public static ThroughputTracker createThroughputTracker(SiddhiAppContext siddhiAppContext, String name,
-                                                            String type, String function) {
+                                                            String type, String function,
+                                                            StatisticsTrackerFactory.MetricsLogLevel metricsLogLevel) {
         ThroughputTracker throughputTracker = null;
         if (siddhiAppContext.getStatisticsManager() != null) {
             String metricName =
@@ -282,7 +285,7 @@ public class QueryParserHelper {
                         .getSiddhiContext()
                         .getStatisticsConfiguration()
                         .getFactory()
-                        .createThroughputTracker(metricName, siddhiAppContext.getStatisticsManager());
+                        .createThroughputTracker(metricName, siddhiAppContext.getStatisticsManager(), metricsLogLevel);
             }
         }
         return throughputTracker;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/statistics/StatisticsTrackerFactory.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/statistics/StatisticsTrackerFactory.java
@@ -27,14 +27,30 @@ import java.util.List;
  */
 public interface StatisticsTrackerFactory {
 
-    LatencyTracker createLatencyTracker(String name, StatisticsManager statisticsManager);
+    LatencyTracker createLatencyTracker(String name, StatisticsManager statisticsManager,
+                                        MetricsLogLevel metricsLogLevel);
 
-    ThroughputTracker createThroughputTracker(String name, StatisticsManager statisticsManager);
+    ThroughputTracker createThroughputTracker(String name, StatisticsManager statisticsManager,
+                                              MetricsLogLevel metricsLogLevel);
 
-    BufferedEventsTracker createBufferSizeTracker(StatisticsManager statisticsManager);
+    BufferedEventsTracker createBufferSizeTracker(StatisticsManager statisticsManager, MetricsLogLevel metricsLogLevel);
 
-    MemoryUsageTracker createMemoryUsageTracker(StatisticsManager statisticsManager);
+    MemoryUsageTracker createMemoryUsageTracker(StatisticsManager statisticsManager, MetricsLogLevel metricsLogLevel);
 
-    StatisticsManager createStatisticsManager(String prefix, String siddhiAppName, List<Element> elements);
+    StatisticsManager createStatisticsManager(String prefix, String siddhiAppName, List<Element> elements,
+                                              boolean isStatisticsEnabled);
+
+    Comparable getLogLevel(MetricsLogLevel metricsLogLevel);
+
+    /**
+     * Levels of metrics
+     */
+    public enum MetricsLogLevel {
+        OFF,
+        INFO,
+        DEBUG,
+        TRACE,
+        ALL
+    }
 
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/statistics/metrics/SiddhiMetricsFactory.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/statistics/metrics/SiddhiMetricsFactory.java
@@ -33,25 +33,35 @@ import java.util.List;
  */
 public class SiddhiMetricsFactory implements StatisticsTrackerFactory {
 
-    public LatencyTracker createLatencyTracker(String name, StatisticsManager statisticsManager) {
+    public LatencyTracker createLatencyTracker(String name, StatisticsManager statisticsManager,
+                                               MetricsLogLevel metricsLogLevel) {
         return new SiddhiLatencyMetric(name, ((SiddhiStatisticsManager) statisticsManager).getRegistry());
     }
 
-    public ThroughputTracker createThroughputTracker(String name, StatisticsManager statisticsManager) {
+    public ThroughputTracker createThroughputTracker(String name, StatisticsManager statisticsManager,
+                                                     MetricsLogLevel metricsLogLevel) {
         return new SiddhiThroughputMetric(name, ((SiddhiStatisticsManager) statisticsManager).getRegistry());
     }
 
-    public BufferedEventsTracker createBufferSizeTracker(StatisticsManager statisticsManager) {
+    public BufferedEventsTracker createBufferSizeTracker(StatisticsManager statisticsManager,
+                                                         MetricsLogLevel metricsLogLevel) {
         return new SiddhiBufferedEventsMetric(((SiddhiStatisticsManager) statisticsManager).getRegistry());
     }
 
-    public MemoryUsageTracker createMemoryUsageTracker(StatisticsManager statisticsManager) {
+    public MemoryUsageTracker createMemoryUsageTracker(StatisticsManager statisticsManager,
+                                                       MetricsLogLevel metricsLogLevel) {
         return new SiddhiMemoryUsageMetric(((SiddhiStatisticsManager) statisticsManager).getRegistry());
     }
 
     @Override
-    public StatisticsManager createStatisticsManager(String prefix, String siddhiAppName, List<Element> elements) {
+    public StatisticsManager createStatisticsManager(String prefix, String siddhiAppName, List<Element> elements,
+                                                     boolean isStatisticsEnabled) {
         return new SiddhiStatisticsManager(elements);
+    }
+
+    @Override
+    public Comparable getLogLevel(MetricsLogLevel metricsLogLevel) {
+        return null;
     }
 
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.wso2.siddhi.core.util.statistics.StatisticsTrackerFactory.MetricsLogLevel.INFO;
+
 /**
  * Window implementation of SiddhiQL.
  * It can be seen as a global Window which can be accessed from multiple queries.
@@ -126,14 +128,16 @@ public class Window implements FindableProcessor, Snapshotable, MemoryCalculable
         this.lockWrapper.setLock(new ReentrantLock());
         if (siddhiAppContext.getStatisticsManager() != null) {
             latencyTrackerFind = QueryParserHelper.createLatencyTracker(siddhiAppContext, windowDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND);
+                    SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND, INFO);
             latencyTrackerInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext, windowDefinition.getId(),
-                    SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT);
+                    SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT, INFO);
 
             throughputTrackerFind = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                    windowDefinition.getId(), SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND);
+                    windowDefinition.getId(), SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND,
+                    INFO);
             throughputTrackerInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                    windowDefinition.getId(), SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT);
+                    windowDefinition.getId(), SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT,
+                    INFO);
         }
     }
 


### PR DESCRIPTION
## Purpose
> components can implement getLogLevel() and in-order to use with metrics levels

## Notes
> Currently, all the levels have been set to INFO. After performance tuning the siddhi metrics levels should be changed accordingly.