### PR TITLE
Fix stream event cloner while cloning non-primitive attributes and non-blocking publishing in in-memory broker

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -203,5 +203,4 @@
         <Package name="~org\.wso2\.siddhi\.sample.*"/>
     </Match>
 
-
 </FindBugsFilter>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -133,7 +133,7 @@
         <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
     </Match>
     <Match>
-        <Class name="org.wso2.siddhi.core.util.transport.InMemoryBroker$Subscriber"/>
+        <Class name="org.wso2.siddhi.core.util.transport.InMemoryBroker$MessageBroker"/>
         <Bug pattern="DE_MIGHT_IGNORE"/>
     </Match>
     <Match>
@@ -202,5 +202,6 @@
     <Match>
         <Package name="~org\.wso2\.siddhi\.sample.*"/>
     </Match>
+
 
 </FindBugsFilter>

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2005 - 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.wso2.siddhi.core.event.stream;
 
 /**

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
@@ -1,7 +1,7 @@
 package org.wso2.siddhi.core.event.stream;
 
 /**
- * Cloner interface to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
+ * Cloner interface to be implemented when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
  */
 public interface StreamEventCloner {
     StreamEvent copyStreamEvent(StreamEvent streamEvent);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
@@ -1,16 +1,19 @@
 /*
  * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy
- * of the License at
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed
- * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.siddhi.core.event.stream;
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 - 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventCloner.java
@@ -1,63 +1,8 @@
-/*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.wso2.siddhi.core.event.stream;
 
 /**
- * Cloner class for {@link StreamEvent} to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
+ * Cloner interface to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
  */
-public class StreamEventCloner {
-
-    private final int beforeWindowDataSize;
-    private final int onAfterWindowDataSize;
-    private final int outputDataSize;
-    private final StreamEventPool streamEventPool;
-
-    public StreamEventCloner(MetaStreamEvent metaStreamEvent, StreamEventPool streamEventPool) {
-
-        this.streamEventPool = streamEventPool;
-        this.beforeWindowDataSize = metaStreamEvent.getBeforeWindowData().size();
-        this.onAfterWindowDataSize = metaStreamEvent.getOnAfterWindowData().size();
-        this.outputDataSize = metaStreamEvent.getOutputData().size();
-
-    }
-
-    /**
-     * Method to copy new StreamEvent from StreamEvent
-     *
-     * @param streamEvent StreamEvent to be copied
-     * @return StreamEvent
-     */
-    public StreamEvent copyStreamEvent(StreamEvent streamEvent) {
-        StreamEvent borrowedEvent = streamEventPool.borrowEvent();
-        if (beforeWindowDataSize > 0) {
-            System.arraycopy(streamEvent.getBeforeWindowData(), 0, borrowedEvent.getBeforeWindowData(), 0,
-                             beforeWindowDataSize);
-        }
-        if (onAfterWindowDataSize > 0) {
-            System.arraycopy(streamEvent.getOnAfterWindowData(), 0, borrowedEvent.getOnAfterWindowData(), 0,
-                             onAfterWindowDataSize);
-        }
-        if (outputDataSize > 0) {
-            System.arraycopy(streamEvent.getOutputData(), 0, borrowedEvent.getOutputData(), 0, outputDataSize);
-        }
-        borrowedEvent.setType(streamEvent.getType());
-        borrowedEvent.setTimestamp(streamEvent.getTimestamp());
-        return borrowedEvent;
-    }
+public interface StreamEventCloner {
+    StreamEvent copyStreamEvent(StreamEvent streamEvent);
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventDeepCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventDeepCloner.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.siddhi.core.event.stream;
 
-import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -47,7 +47,6 @@ public class StreamEventDeepCloner implements StreamEventCloner {
         this.beforeWindowDataSize = metaStreamEvent.getBeforeWindowData().size();
         this.onAfterWindowDataSize = metaStreamEvent.getOnAfterWindowData().size();
         this.outputDataSize = metaStreamEvent.getOutputData().size();
-
     }
 
     /**
@@ -90,9 +89,9 @@ public class StreamEventDeepCloner implements StreamEventCloner {
             final T readObject = (T) in.readObject();
             return readObject;
         } catch (final ClassNotFoundException ex) {
-            throw new SiddhiAppRuntimeException("ClassNotFoundException while reading cloned object data", ex);
+            throw new SiddhiAppCreationException("ClassNotFoundException while reading cloned object data", ex);
         } catch (final IOException ex) {
-            throw new SiddhiAppRuntimeException("IOException while reading or closing cloned object data", ex);
+            throw new SiddhiAppCreationException("IOException while reading or closing cloned object data", ex);
         }
     }
 
@@ -107,8 +106,7 @@ public class StreamEventDeepCloner implements StreamEventCloner {
             try (ObjectOutputStream out = new ObjectOutputStream(outputStream)) {
                 out.writeObject(obj);
             } catch (final IOException ex) {
-                throw new SiddhiAppRuntimeException(ex);
-
+                throw new SiddhiAppCreationException(ex);
             }
         }
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventDeepCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventDeepCloner.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.siddhi.core.event.stream;
+
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cloner class for {@link StreamEvent} to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
+ */
+public class StreamEventDeepCloner implements StreamEventCloner {
+
+    protected final int beforeWindowDataSize;
+    protected final int onAfterWindowDataSize;
+    protected final int outputDataSize;
+    protected final StreamEventPool streamEventPool;
+
+    public StreamEventDeepCloner(MetaStreamEvent metaStreamEvent, StreamEventPool streamEventPool) {
+        this.streamEventPool = streamEventPool;
+        this.beforeWindowDataSize = metaStreamEvent.getBeforeWindowData().size();
+        this.onAfterWindowDataSize = metaStreamEvent.getOnAfterWindowData().size();
+        this.outputDataSize = metaStreamEvent.getOutputData().size();
+
+    }
+
+    /**
+     * Method to copy new StreamEvent from StreamEvent
+     *
+     * @param streamEvent StreamEvent to be copied
+     * @return StreamEvent
+     */
+    public StreamEvent copyStreamEvent(StreamEvent streamEvent) {
+        StreamEvent borrowedEvent = streamEventPool.borrowEvent();
+        if (beforeWindowDataSize > 0) {
+            borrowedEvent.setBeforeWindowData(clone(streamEvent.getBeforeWindowData()));
+        }
+        if (onAfterWindowDataSize > 0) {
+            borrowedEvent.setOnAfterWindowData(clone(streamEvent.getOnAfterWindowData()));
+        }
+        if (outputDataSize > 0) {
+            borrowedEvent.setOutputData(clone(streamEvent.getOutputData()));
+        }
+        borrowedEvent.setType(streamEvent.getType());
+        borrowedEvent.setTimestamp(streamEvent.getTimestamp());
+        return borrowedEvent;
+    }
+
+    /**
+     *
+     * @param object
+     * @param <T>
+     * @return
+     */
+    private static <T extends Serializable> T clone(final T object) {
+        if (object == null) {
+            return null;
+        }
+        final byte[] objectData = serialize(object);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(objectData);
+
+        try (ClassLoaderAwareObjectInputStream in = new ClassLoaderAwareObjectInputStream(bais,
+                object.getClass().getClassLoader())) {
+            /*
+             * when we serialize and deserialize an object,
+             * it is reasonable to assume the deserialized object
+             * is of the same type as the original serialized object
+             */
+            @SuppressWarnings("unchecked") // see above
+            final T readObject = (T) in.readObject();
+            return readObject;
+        } catch (final ClassNotFoundException ex) {
+            throw new SiddhiAppRuntimeException("ClassNotFoundException while reading cloned object data", ex);
+        } catch (final IOException ex) {
+            throw new SiddhiAppRuntimeException("IOException while reading or closing cloned object data", ex);
+        }
+    }
+
+    /**
+     *
+     * @param obj
+     * @return
+     */
+    private static byte[] serialize(final Serializable obj) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+        serialize(obj, baos);
+        return baos.toByteArray();
+    }
+
+    /**
+     *
+     * @param obj
+     * @param outputStream
+     */
+    private static void serialize(final Serializable obj, final OutputStream outputStream) {
+        if (outputStream != null) {
+            try (ObjectOutputStream out = new ObjectOutputStream(outputStream)) {
+                out.writeObject(obj);
+            } catch (final IOException ex) {
+                throw new SiddhiAppRuntimeException(ex);
+
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    static class ClassLoaderAwareObjectInputStream extends ObjectInputStream {
+        /**
+         *
+         */
+        private static final Map<String, Class<?>> primitiveTypes =
+                new HashMap<>();
+        static {
+            primitiveTypes.put("byte", byte.class);
+            primitiveTypes.put("short", short.class);
+            primitiveTypes.put("int", int.class);
+            primitiveTypes.put("long", long.class);
+            primitiveTypes.put("float", float.class);
+            primitiveTypes.put("double", double.class);
+            primitiveTypes.put("boolean", boolean.class);
+            primitiveTypes.put("char", char.class);
+            primitiveTypes.put("void", void.class);
+        }
+
+        private final ClassLoader classLoader;
+
+        /**
+         * Constructor.
+         *
+         * @param in          The <code>InputStream</code>.
+         * @param classLoader classloader to use
+         * @throws IOException if an I/O error occurs while reading stream header.
+         * @see java.io.ObjectInputStream
+         */
+        ClassLoaderAwareObjectInputStream(final InputStream in, final ClassLoader classLoader) throws IOException {
+            super(in);
+            this.classLoader = classLoader;
+        }
+
+        /**
+         * Overridden version that uses the parameterized <code>ClassLoader</code> or the <code>ClassLoader</code>
+         * of the current <code>Thread</code> to resolve the class.
+         *
+         * @param desc An instance of class <code>ObjectStreamClass</code>.
+         * @return A <code>Class</code> object corresponding to <code>desc</code>.
+         * @throws IOException            Any of the usual Input/Output exceptions.
+         * @throws ClassNotFoundException If class of a serialized object cannot be found.
+         */
+        @Override
+        protected Class<?> resolveClass(final ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+            final String name = desc.getName();
+            try {
+                return Class.forName(name, false, classLoader);
+            } catch (final ClassNotFoundException ex) {
+                try {
+                    return Class.forName(name, false, Thread.currentThread().getContextClassLoader());
+                } catch (final ClassNotFoundException cnfe) {
+                    final Class<?> cls = primitiveTypes.get(name);
+                    if (cls != null) {
+                        return cls;
+                    }
+                    throw cnfe;
+                }
+            }
+        }
+
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventDeepCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventDeepCloner.java
@@ -32,7 +32,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Cloner class for {@link StreamEvent} to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
+ * Implementation class for Deep {@link StreamEvent} cloner to be used when creating
+ * {@link org.wso2.siddhi.core.partition.PartitionRuntime}
  */
 public class StreamEventDeepCloner implements StreamEventCloner {
 
@@ -71,12 +72,6 @@ public class StreamEventDeepCloner implements StreamEventCloner {
         return borrowedEvent;
     }
 
-    /**
-     *
-     * @param object
-     * @param <T>
-     * @return
-     */
     private static <T extends Serializable> T clone(final T object) {
         if (object == null) {
             return null;
@@ -101,22 +96,12 @@ public class StreamEventDeepCloner implements StreamEventCloner {
         }
     }
 
-    /**
-     *
-     * @param obj
-     * @return
-     */
     private static byte[] serialize(final Serializable obj) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
         serialize(obj, baos);
         return baos.toByteArray();
     }
 
-    /**
-     *
-     * @param obj
-     * @param outputStream
-     */
     private static void serialize(final Serializable obj, final OutputStream outputStream) {
         if (outputStream != null) {
             try (ObjectOutputStream out = new ObjectOutputStream(outputStream)) {
@@ -128,13 +113,7 @@ public class StreamEventDeepCloner implements StreamEventCloner {
         }
     }
 
-    /**
-     *
-     */
     static class ClassLoaderAwareObjectInputStream extends ObjectInputStream {
-        /**
-         *
-         */
         private static final Map<String, Class<?>> primitiveTypes =
                 new HashMap<>();
         static {
@@ -190,6 +169,5 @@ public class StreamEventDeepCloner implements StreamEventCloner {
                 }
             }
         }
-
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventShallowCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventShallowCloner.java
@@ -19,7 +19,8 @@
 package org.wso2.siddhi.core.event.stream;
 
 /**
- * Cloner class for {@link StreamEvent} to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
+ * Implementation class for Shallow {@link StreamEvent} cloner to be used when creating
+ * {@link org.wso2.siddhi.core.partition.PartitionRuntime}
  */
 public class StreamEventShallowCloner implements StreamEventCloner {
 
@@ -33,7 +34,6 @@ public class StreamEventShallowCloner implements StreamEventCloner {
         this.beforeWindowDataSize = metaStreamEvent.getBeforeWindowData().size();
         this.onAfterWindowDataSize = metaStreamEvent.getOnAfterWindowData().size();
         this.outputDataSize = metaStreamEvent.getOutputData().size();
-
     }
 
     /**

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventShallowCloner.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/event/stream/StreamEventShallowCloner.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.event.stream;
+
+/**
+ * Cloner class for {@link StreamEvent} to be used when creating {@link org.wso2.siddhi.core.partition.PartitionRuntime}
+ */
+public class StreamEventShallowCloner implements StreamEventCloner {
+
+    protected final int beforeWindowDataSize;
+    protected final int onAfterWindowDataSize;
+    protected final int outputDataSize;
+    protected final StreamEventPool streamEventPool;
+
+    public StreamEventShallowCloner(MetaStreamEvent metaStreamEvent, StreamEventPool streamEventPool) {
+        this.streamEventPool = streamEventPool;
+        this.beforeWindowDataSize = metaStreamEvent.getBeforeWindowData().size();
+        this.onAfterWindowDataSize = metaStreamEvent.getOnAfterWindowData().size();
+        this.outputDataSize = metaStreamEvent.getOutputData().size();
+
+    }
+
+    /**
+     * Method to copy new StreamEvent from StreamEvent
+     *
+     * @param streamEvent StreamEvent to be copied
+     * @return StreamEvent
+     */
+    public StreamEvent copyStreamEvent(StreamEvent streamEvent) {
+        StreamEvent borrowedEvent = streamEventPool.borrowEvent();
+        if (beforeWindowDataSize > 0) {
+            System.arraycopy(streamEvent.getBeforeWindowData(), 0, borrowedEvent.getBeforeWindowData(), 0,
+                             beforeWindowDataSize);
+        }
+        if (onAfterWindowDataSize > 0) {
+            System.arraycopy(streamEvent.getOnAfterWindowData(), 0, borrowedEvent.getOnAfterWindowData(), 0,
+                             onAfterWindowDataSize);
+        }
+        if (outputDataSize > 0) {
+            System.arraycopy(streamEvent.getOutputData(), 0, borrowedEvent.getOutputData(), 0, outputDataSize);
+        }
+        borrowedEvent.setType(streamEvent.getType());
+        borrowedEvent.setTimestamp(streamEvent.getTimestamp());
+        return borrowedEvent;
+    }
+}

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/output/ratelimit/snapshot/WrappedSnapshotOutputRateLimiter.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/output/ratelimit/snapshot/WrappedSnapshotOutputRateLimiter.java
@@ -25,8 +25,8 @@ import org.wso2.siddhi.core.event.state.MetaStateEvent;
 import org.wso2.siddhi.core.event.state.StateEventCloner;
 import org.wso2.siddhi.core.event.state.StateEventPool;
 import org.wso2.siddhi.core.event.stream.MetaStreamEvent;
-import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
+import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.query.output.ratelimit.OutputRateLimiter;
 import org.wso2.siddhi.core.query.selector.attribute.processor.AttributeProcessor;
 import org.wso2.siddhi.core.query.selector.attribute.processor.executor.AbstractAggregationAttributeExecutor;
@@ -133,7 +133,7 @@ public class WrappedSnapshotOutputRateLimiter extends OutputRateLimiter {
                                                                        stateEventPool));
         } else {
             StreamEventPool streamEventPool = new StreamEventPool((MetaStreamEvent) metaComplexEvent, 5);
-            outputRateLimiter.setStreamEventCloner(new StreamEventCloner((MetaStreamEvent) metaComplexEvent,
+            outputRateLimiter.setStreamEventCloner(new StreamEventShallowCloner((MetaStreamEvent) metaComplexEvent,
                                                                          streamEventPool));
         }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
@@ -29,6 +29,7 @@ import org.wso2.siddhi.core.event.stream.MetaStreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
+import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.event.stream.populater.ComplexEventPopulater;
 import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
@@ -81,10 +82,11 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
         this.aggregateMetaStreamEvent = aggregateMetaSteamEvent;
 
         this.streamEventPoolForTableMeta = new StreamEventPool(tableMetaStreamEvent, 10);
-        this.tableEventCloner = new StreamEventCloner(tableMetaStreamEvent, streamEventPoolForTableMeta);
+        this.tableEventCloner = new StreamEventShallowCloner(tableMetaStreamEvent, streamEventPoolForTableMeta);
 
         this.streamEventPoolForAggregateMeta = new StreamEventPool(aggregateMetaSteamEvent, 10);
-        this.aggregateEventCloner = new StreamEventCloner(aggregateMetaSteamEvent, streamEventPoolForAggregateMeta);
+        this.aggregateEventCloner = new StreamEventShallowCloner(aggregateMetaSteamEvent,
+                streamEventPoolForAggregateMeta);
         this.additionalAttributes = additionalAttributes;
         this.alteredMatchingMetaInfoHolder = alteredMatchingMetaInfoHolder;
         this.perExpressionExecutor = perExpressionExecutor;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/EventHolderPasser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/EventHolderPasser.java
@@ -21,8 +21,8 @@ package org.wso2.siddhi.core.util.parser;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
 import org.wso2.siddhi.core.event.stream.MetaStreamEvent;
-import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
+import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.event.stream.converter.ZeroStreamEventConverter;
 import org.wso2.siddhi.core.event.stream.holder.StreamEventClonerHolder;
 import org.wso2.siddhi.core.exception.OperationNotSupportedException;
@@ -117,7 +117,7 @@ public class EventHolderPasser {
             for (Attribute attribute : tableDefinition.getAttributeList()) {
                 metaStreamEvent.addOutputData(attribute);
             }
-            StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent, tableStreamEventPool);
+            StreamEventShallowCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent, tableStreamEventPool);
             return new ListEventHolder(tableStreamEventPool, eventConverter,
                     new StreamEventClonerHolder(streamEventCloner));
         }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/EventHolderPasser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/EventHolderPasser.java
@@ -21,6 +21,7 @@ package org.wso2.siddhi.core.util.parser;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
 import org.wso2.siddhi.core.event.stream.MetaStreamEvent;
+import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
 import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.event.stream.converter.ZeroStreamEventConverter;
@@ -117,7 +118,7 @@ public class EventHolderPasser {
             for (Attribute attribute : tableDefinition.getAttributeList()) {
                 metaStreamEvent.addOutputData(attribute);
             }
-            StreamEventShallowCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent, tableStreamEventPool);
+            StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent, tableStreamEventPool);
             return new ListEventHolder(tableStreamEventPool, eventConverter,
                     new StreamEventClonerHolder(streamEventCloner));
         }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -22,6 +22,7 @@ import org.wso2.siddhi.core.config.SiddhiAppContext;
 import org.wso2.siddhi.core.event.stream.MetaStreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
+import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 import org.wso2.siddhi.core.function.Script;
 import org.wso2.siddhi.core.stream.StreamJunction;
@@ -167,7 +168,7 @@ public class DefinitionParserHelper {
             }
 
             StreamEventPool tableStreamEventPool = new StreamEventPool(tableMetaStreamEvent, 10);
-            StreamEventCloner tableStreamEventCloner = new StreamEventCloner(tableMetaStreamEvent,
+            StreamEventCloner tableStreamEventCloner = new StreamEventShallowCloner(tableMetaStreamEvent,
                     tableStreamEventPool);
 
             Annotation annotation = AnnotationHelper.getAnnotation(SiddhiConstants.ANNOTATION_STORE,

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
@@ -174,20 +174,15 @@ public class QueryParserHelper {
                                                 LockWrapper lockWrapper, String queryName) {
         MetaStreamEvent metaStreamEvent;
         boolean deepCopy = false;
-
         if (metaComplexEvent instanceof MetaStateEvent) {
             metaStreamEvent = ((MetaStateEvent) metaComplexEvent).getMetaStreamEvent(streamEventChainIndex);
         } else {
             metaStreamEvent = (MetaStreamEvent) metaComplexEvent;
         }
-        outerloop:
         for (AbstractDefinition streamDefs : metaStreamEvent.getInputDefinitions()) {
-            List<Attribute> attrTypes = streamDefs.getAttributeList();
-            for (Attribute attr : attrTypes) {
-                if (attr.getType().equals(Attribute.Type.OBJECT)) {
-                    deepCopy = true;
-                    break outerloop;
-                }
+            if (DefinitionParserHelper.containsNonPrimitives(streamDefs)) {
+                deepCopy = true;
+                break;
             }
         }
         StreamEventPool streamEventPool = new StreamEventPool(metaStreamEvent, 5);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
@@ -67,7 +67,6 @@ import static org.wso2.siddhi.core.util.SiddhiConstants.UNKNOWN_STATE;
 public class QueryParserHelper {
 
     public static void reduceMetaComplexEvent(MetaComplexEvent metaComplexEvent) {
-
         if (metaComplexEvent instanceof MetaStateEvent) {
             MetaStateEvent metaStateEvent = (MetaStateEvent) metaComplexEvent;
             for (MetaStateEventAttribute attribute : metaStateEvent.getOutputDataAttributes()) {
@@ -90,7 +89,6 @@ public class QueryParserHelper {
      * @param metaStreamEvent MetaStreamEvent
      */
     private static synchronized void reduceStreamAttributes(MetaStreamEvent metaStreamEvent) {
-
         for (Attribute attribute : metaStreamEvent.getOutputData()) {
             if (metaStreamEvent.getBeforeWindowData().contains(attribute)) {
                 metaStreamEvent.getBeforeWindowData().remove(attribute);
@@ -174,7 +172,6 @@ public class QueryParserHelper {
     private static void initSingleStreamRuntime(SingleStreamRuntime singleStreamRuntime, int streamEventChainIndex,
                                                 MetaComplexEvent metaComplexEvent, StateEventPool stateEventPool,
                                                 LockWrapper lockWrapper, String queryName) {
-
         MetaStreamEvent metaStreamEvent;
         boolean deepCopy = false;
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/helper/QueryParserHelper.java
@@ -243,7 +243,6 @@ public class QueryParserHelper {
 
     public static LatencyTracker createLatencyTracker(SiddhiAppContext siddhiAppContext, String name, String type,
                                                       String function) {
-
         LatencyTracker latencyTracker = null;
         if (siddhiAppContext.getStatisticsManager() != null) {
             String metricName =
@@ -276,7 +275,6 @@ public class QueryParserHelper {
 
     public static ThroughputTracker createThroughputTracker(SiddhiAppContext siddhiAppContext, String name,
                                                             String type, String function) {
-
         ThroughputTracker throughputTracker = null;
         if (siddhiAppContext.getStatisticsManager() != null) {
             String metricName =
@@ -311,7 +309,6 @@ public class QueryParserHelper {
     public static void registerMemoryUsageTracking(String name, Object value, String metricInfixQueries,
                                                    SiddhiAppContext siddhiAppContext,
                                                    MemoryUsageTracker memoryUsageTracker) {
-
         String metricName = siddhiAppContext.getSiddhiContext().getStatisticsConfiguration().getMetricPrefix() +
                 SiddhiConstants.METRIC_DELIMITER + SiddhiConstants.METRIC_INFIX_SIDDHI_APPS +
                 SiddhiConstants.METRIC_DELIMITER + siddhiAppContext.getName() + SiddhiConstants.METRIC_DELIMITER +

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
@@ -43,6 +43,7 @@ import org.wso2.siddhi.core.util.collection.operator.MatchingMetaInfoHolder;
 import org.wso2.siddhi.core.util.lock.LockWrapper;
 import org.wso2.siddhi.core.util.parser.SchedulerParser;
 import org.wso2.siddhi.core.util.parser.SingleInputStreamParser;
+import org.wso2.siddhi.core.util.parser.helper.DefinitionParserHelper;
 import org.wso2.siddhi.core.util.parser.helper.QueryParserHelper;
 import org.wso2.siddhi.core.util.snapshot.Snapshotable;
 import org.wso2.siddhi.core.util.statistics.LatencyTracker;
@@ -149,15 +150,9 @@ public class Window implements FindableProcessor, Snapshotable, MemoryCalculable
     public void init(Map<String, Table> tableMap, Map<String, Window> eventWindowMap,
                      String queryName) {
         StreamEventCloner streamEventCloner;
-        boolean deepCopy = false;
+        boolean deepCopy = DefinitionParserHelper.containsNonPrimitives(windowDefinition);
         if (this.windowProcessor != null) {
             return;
-        }
-        for (Attribute attribute : windowDefinition.getAttributeList()) {
-            if (attribute.getType().equals(Attribute.Type.OBJECT)) {
-                deepCopy = true;
-                break;
-            }
         }
         // Create and initialize MetaStreamEvent
         MetaStreamEvent metaStreamEvent = new MetaStreamEvent();
@@ -167,7 +162,6 @@ public class Window implements FindableProcessor, Snapshotable, MemoryCalculable
         for (Attribute attribute : windowDefinition.getAttributeList()) {
             metaStreamEvent.addOutputData(attribute);
         }
-
         this.streamEventPool = new StreamEventPool(metaStreamEvent, 5);
         if (deepCopy) {
             streamEventCloner = new StreamEventDeepCloner(metaStreamEvent, this.streamEventPool);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/window/Window.java
@@ -24,6 +24,7 @@ import org.wso2.siddhi.core.event.stream.MetaStreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
+import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.event.stream.converter.ZeroStreamEventConverter;
 import org.wso2.siddhi.core.exception.OperationNotSupportedException;
 import org.wso2.siddhi.core.executor.VariableExpressionExecutor;
@@ -160,7 +161,7 @@ public class Window implements FindableProcessor, Snapshotable, MemoryCalculable
         }
 
         this.streamEventPool = new StreamEventPool(metaStreamEvent, 5);
-        StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent, this.streamEventPool);
+        StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent, this.streamEventPool);
         OutputStream.OutputEventType outputEventType = windowDefinition.getOutputEventType();
         boolean outputExpectsExpiredEvents = outputEventType != OutputStream.OutputEventType.CURRENT_EVENTS;
 

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/managment/SnapshotableEventQueueTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/managment/SnapshotableEventQueueTestCase.java
@@ -27,6 +27,7 @@ import org.wso2.siddhi.core.event.stream.Operation;
 import org.wso2.siddhi.core.event.stream.StreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
+import org.wso2.siddhi.core.event.stream.StreamEventShallowCloner;
 import org.wso2.siddhi.core.event.stream.holder.SnapshotableStreamEventQueue;
 import org.wso2.siddhi.core.event.stream.holder.StreamEventClonerHolder;
 import org.wso2.siddhi.core.util.snapshot.state.SnapshotState;
@@ -59,7 +60,7 @@ public class SnapshotableEventQueueTestCase {
         metaStreamEvent.addOutputData(new Attribute("price", Attribute.Type.FLOAT));
         metaStreamEvent.addOutputData(new Attribute("volume", Attribute.Type.LONG));
 
-        StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent,
+        StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent,
                 new StreamEventPool(metaStreamEvent, 5));
 
         SnapshotableStreamEventQueue snapshotableStreamEventQueue =
@@ -139,7 +140,7 @@ public class SnapshotableEventQueueTestCase {
         metaStreamEvent.addOutputData(new Attribute("price", Attribute.Type.FLOAT));
         metaStreamEvent.addOutputData(new Attribute("volume", Attribute.Type.LONG));
 
-        StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent,
+        StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent,
                 new StreamEventPool(metaStreamEvent, 5));
 
         SnapshotableStreamEventQueue snapshotableStreamEventQueue =
@@ -198,7 +199,7 @@ public class SnapshotableEventQueueTestCase {
         metaStreamEvent.addOutputData(new Attribute("price", Attribute.Type.FLOAT));
         metaStreamEvent.addOutputData(new Attribute("volume", Attribute.Type.LONG));
 
-        StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent,
+        StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent,
                 new StreamEventPool(metaStreamEvent, 5));
         SnapshotableStreamEventQueue snapshotableStreamEventQueue =
                 new SnapshotableStreamEventQueue(new StreamEventClonerHolder(streamEventCloner));
@@ -259,7 +260,7 @@ public class SnapshotableEventQueueTestCase {
         metaStreamEvent.addOutputData(new Attribute("price", Attribute.Type.FLOAT));
         metaStreamEvent.addOutputData(new Attribute("volume", Attribute.Type.LONG));
 
-        StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent,
+        StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent,
                 new StreamEventPool(metaStreamEvent, 5));
         SnapshotableStreamEventQueue snapshotableStreamEventQueue =
                 new SnapshotableStreamEventQueue(new StreamEventClonerHolder(streamEventCloner));
@@ -322,7 +323,7 @@ public class SnapshotableEventQueueTestCase {
         metaStreamEvent.addOutputData(new Attribute("price", Attribute.Type.FLOAT));
         metaStreamEvent.addOutputData(new Attribute("volume", Attribute.Type.LONG));
 
-        StreamEventCloner streamEventCloner = new StreamEventCloner(metaStreamEvent,
+        StreamEventCloner streamEventCloner = new StreamEventShallowCloner(metaStreamEvent,
                 new StreamEventPool(metaStreamEvent, 5));
         SnapshotableStreamEventQueue snapshotableStreamEventQueue =
                 new SnapshotableStreamEventQueue(new StreamEventClonerHolder(streamEventCloner));


### PR DESCRIPTION
## Purpose
> Fixes #949 and #948 

## Goals
> Fixes copying object refernces while cloning.
> Fixes in-memory blocker to perform non-blocking publishing