### PR TITLE
Add delete periodic persistence store functionality

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiAppRuntime.java
@@ -658,6 +658,18 @@ public class SiddhiAppRuntime {
         return revision;
     }
 
+    public void clearAllRevisionsOfSiddhiAppInPersistenceStore() {
+        try {
+            // first, pause all the event sources
+            sourceMap.values().forEach(list -> list.forEach(Source::pause));
+            // start the restoring process
+            siddhiAppContext.getSnapshotService().clearAllRevisions();
+        } finally {
+            // at the end, resume the event sources
+            sourceMap.values().forEach(list -> list.forEach(Source::resume));
+        }
+    }
+
     private void monitorQueryMemoryUsage() {
         memoryUsageTracker = siddhiAppContext
                 .getSiddhiContext()

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/FileSystemPersistenceStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/FileSystemPersistenceStore.java
@@ -117,6 +117,31 @@ public class FileSystemPersistenceStore implements PersistenceStore {
         return lastRevision;
     }
 
+    @Override
+    public void clearAllRevisions(String siddhiAppName) {
+        File targetDirectory = new File(folder + File.separator + siddhiAppName);
+        File[] files = targetDirectory.listFiles();
+
+        if (files == null || files.length == 0) {
+            log.info("No revisions were found with the Siddhi App " + siddhiAppName);
+            return;
+        }
+
+        try {
+            for (File file : files) {
+                if (file.exists()) {
+                    if (!file.delete()) {
+                        log.error("file is not deleted successfully!");
+                    }
+                }
+
+            }
+        } catch (Exception e) {
+            log.error("Error deleting the revisions of the persistence store of Siddhi App " + siddhiAppName +
+                    " from file system.", e);
+        }
+    }
+
     /**
      * Method to remove revisions that are older than the user specified amount
      *

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/InMemoryPersistenceStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/InMemoryPersistenceStore.java
@@ -81,6 +81,11 @@ public class InMemoryPersistenceStore implements PersistenceStore {
     }
 
     @Override
+    public void clearAllRevisions(String siddhiAppId) {
+
+    }
+
+    @Override
     public void setProperties(Map properties) {
         //no properties to add
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/IncrementalFileSystemPersistenceStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/IncrementalFileSystemPersistenceStore.java
@@ -143,6 +143,29 @@ public class IncrementalFileSystemPersistenceStore implements IncrementalPersist
         return null;
     }
 
+    @Override
+    public void clearAllRevisions(String siddhiAppName) {
+        File dir = new File(folder + File.separator + siddhiAppName);
+        File[] files = dir.listFiles();
+        if (files == null || files.length == 0) {
+            log.info("No revisions were found with the Siddhi App " + siddhiAppName);
+            return;
+        }
+        try {
+            for (File file : files) {
+                if (file.exists()) {
+                    if (!file.delete()) {
+                        log.error("file is not deleted successfully!");
+                    }
+                }
+
+            }
+        } catch (Exception e) {
+            log.error("Error deleting all the revisions of the persistence store of Siddhi App " + siddhiAppName +
+                    " from file system.", e);
+        }
+    }
+
     private void cleanOldRevisions(IncrementalSnapshotInfo incrementalSnapshotInfo) {
         if (incrementalSnapshotInfo.getType() != IncrementalSnapshotInfo.SnapshotType.INCREMENT) {
             File dir = new File(folder + File.separator + incrementalSnapshotInfo.getSiddhiAppId());

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/IncrementalPersistenceStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/IncrementalPersistenceStore.java
@@ -37,4 +37,6 @@ public interface IncrementalPersistenceStore {
     List<IncrementalSnapshotInfo> getListOfRevisionsToLoad(long restoreTime, String siddhiAppName);
 
     String getLastRevision(String siddhiAppId);
+
+    void clearAllRevisions(String siddhiAppId);
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/PersistenceStore.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/persistence/PersistenceStore.java
@@ -33,4 +33,6 @@ public interface PersistenceStore {
 
     String getLastRevision(String siddhiAppId);
 
+    void clearAllRevisions(String siddhiAppId);
+
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
@@ -529,4 +529,19 @@ public class SnapshotService {
         }
         return revision;
     }
+
+    public void clearAllRevisions() {
+        PersistenceStore persistenceStore = siddhiAppContext.getSiddhiContext().getPersistenceStore();
+        IncrementalPersistenceStore incrementalPersistenceStore =
+                siddhiAppContext.getSiddhiContext().getIncrementalPersistenceStore();
+        String siddhiAppName = siddhiAppContext.getName();
+        if (persistenceStore != null) {
+            persistenceStore.clearAllRevisions(siddhiAppName);
+        } else if (incrementalPersistenceStore != null) {
+            incrementalPersistenceStore.clearAllRevisions(siddhiAppName);
+        } else {
+            throw new NoPersistenceStoreException("No persistence store assigned for siddhi app " + siddhiAppName);
+        }
+    }
+
 }


### PR DESCRIPTION
## Purpose
> Provide the ability to delete the periodic persistence store of a specific Siddhi app or all Siddhi apps

## Approach
> Two approaches were implemented. Through REST end points is one way of deleting periodic persistence store, and the other way is through worker.sh, i.e. when deploying the Siddhi apps.

## Documentation
> You can find the relevant deployment configurations from the [doc](https://docs.google.com/document/d/1x7dHz4DENhhlWVUdoqlAQeVtoLSiEhBJN_gefMjoOik/edit#).

## Automation tests
 - Integration tests
   > Integration tests included. (85 % coverage)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK version: 1.8
Operating system: MacOS 10.14, Windows 10
Database system: mysql, oracle
 
