### PR TITLE
Stabilize build by disable incrementalStreamProcessorTest49 testcase

### DIFF
--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/Aggregation2TestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/Aggregation2TestCase.java
@@ -182,8 +182,9 @@ public class Aggregation2TestCase {
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest48"})
+    @Test(enabled = false, dependsOnMethods = {"incrementalStreamProcessorTest48"})
     public void incrementalStreamProcessorTest49() throws InterruptedException {
+        // Disabling test case until https://github.com/wso2/siddhi/issues/985 is fixed
         LOG.info("incrementalStreamProcessorTest49 - Aggregate on system timestamp and retrieval on non root duration");
         SiddhiManager siddhiManager = new SiddhiManager();
 
@@ -293,7 +294,7 @@ public class Aggregation2TestCase {
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest49"},
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest48"},
             expectedExceptions = StoreQueryCreationException.class)
     public void incrementalStreamProcessorTest50() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest50 - Retrieval query syntax validating ");


### PR DESCRIPTION
## Purpose
$subject. The above test case is failing due to the identified issue https://github.com/wso2/siddhi/issues/985

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes