### PR TITLE
Fix incorrect setting of start time of executors at initialization

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
@@ -129,8 +129,7 @@ public class IncrementalExecutor implements Executor, Snapshotable {
         if (getNextExecutor() != null) {
             StreamEvent timerEvent = streamEventPool.borrowEvent();
             timerEvent.setType(ComplexEvent.Type.TIMER);
-            timerEvent.setTimestamp(
-                    IncrementalTimeConverterUtil.getPreviousStartTime(startTimeOfAggregates, this.duration));
+            timerEvent.setTimestamp(startTimeOfAggregates);
             ComplexEventChunk<StreamEvent> timerStreamEventChunk = new ComplexEventChunk<>(true);
             timerStreamEventChunk.add(timerEvent);
             next.execute(timerStreamEventChunk);

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/Aggregation2TestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/Aggregation2TestCase.java
@@ -182,9 +182,8 @@ public class Aggregation2TestCase {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = {"incrementalStreamProcessorTest48"})
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest48"})
     public void incrementalStreamProcessorTest49() throws InterruptedException {
-        // Disabling test case until https://github.com/wso2/siddhi/issues/985 is fixed
         LOG.info("incrementalStreamProcessorTest49 - Aggregate on system timestamp and retrieval on non root duration");
         SiddhiManager siddhiManager = new SiddhiManager();
 
@@ -294,7 +293,7 @@ public class Aggregation2TestCase {
         }
     }
 
-    @Test(dependsOnMethods = {"incrementalStreamProcessorTest48"},
+    @Test(dependsOnMethods = {"incrementalStreamProcessorTest49"},
             expectedExceptions = StoreQueryCreationException.class)
     public void incrementalStreamProcessorTest50() throws InterruptedException {
         LOG.info("incrementalStreamProcessorTest50 - Retrieval query syntax validating ");


### PR DESCRIPTION
## Purpose
$subject. Fixes incorrect AGG_TIMESTAMP value if the one step down granularity is not completed once. For instance in higher granularity such as the day when queried after starting aggregation for few minutes (before the hour ends). This ONLY happens when the bucket ends (Year: January)
Fixes https://github.com/wso2/siddhi/issues/985

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes