### PR TITLE
Improve throughput of aggregations and change aggregation metric name

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataPurging.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataPurging.java
@@ -200,8 +200,10 @@ public class IncrementalDataPurging implements Runnable {
                 eventChunk.add(secEvent);
                 Table table = aggregationTables.get(entry.getKey());
                 try {
-                    LOG.debug("Purging data of table: " + table.getTableDefinition().getId() + " with a" +
-                            " retention of timestamp : " + purgeTime);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Purging data of table: " + table.getTableDefinition().getId() + " with a" +
+                                " retention of timestamp : " + purgeTime);
+                    }
                     table.deleteEvents(eventChunk, compiledConditionsHolder.get(entry.getKey()), 1);
                 } catch (RuntimeException e) {
                     LOG.error("Exception occurred while deleting events from " +
@@ -285,7 +287,9 @@ public class IncrementalDataPurging implements Runnable {
                     ((purgeExecutionInterval) / 1000) + " seconds in " + aggregationDefinition.getId() +
                     " aggregation");
         } else {
-            LOG.debug("Purging is disabled in siddhi app: " + siddhiAppContext.getName());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Purging is disabled in siddhi app: " + siddhiAppContext.getName());
+            }
         }
     }
 

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
@@ -104,7 +104,9 @@ public class IncrementalExecutor implements Executor, Snapshotable {
 
     @Override
     public void execute(ComplexEventChunk streamEventChunk) {
-        LOG.debug("Event Chunk received by " + this.duration + " incremental executor: " + streamEventChunk.toString());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Event Chunk received by " + this.duration + " incremental executor: " + streamEventChunk.toString());
+        }
         streamEventChunk.reset();
         while (streamEventChunk.hasNext()) {
             StreamEvent streamEvent = (StreamEvent) streamEventChunk.next();
@@ -220,7 +222,9 @@ public class IncrementalExecutor implements Executor, Snapshotable {
             StreamEvent streamEvent = aBaseIncrementalValueStore.createStreamEvent();
             ComplexEventChunk<StreamEvent> eventChunk = new ComplexEventChunk<>(true);
             eventChunk.add(streamEvent);
-            LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
+            }
             if (isProcessingExecutor) {
                 table.addEvents(eventChunk, 1);
             }
@@ -239,7 +243,9 @@ public class IncrementalExecutor implements Executor, Snapshotable {
                 StreamEvent streamEvent = aBaseIncrementalValueStore.createStreamEvent();
                 eventChunk.add(streamEvent);
             }
-            LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
+            }
             if (isProcessingExecutor) {
                 table.addEvents(eventChunk, noOfEvents);
             }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
@@ -105,7 +105,8 @@ public class IncrementalExecutor implements Executor, Snapshotable {
     @Override
     public void execute(ComplexEventChunk streamEventChunk) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Event Chunk received by " + this.duration + " incremental executor: " + streamEventChunk.toString());
+            LOG.debug("Event Chunk received by " + this.duration + " incremental executor: " +
+                    streamEventChunk.toString());
         }
         streamEventChunk.reset();
         while (streamEventChunk.hasNext()) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
@@ -330,17 +330,17 @@ public class AggregationParser {
             if (siddhiAppContext.getStatisticsManager() != null) {
                 latencyTrackerFind = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND);
+                        SiddhiConstants.METRIC_INFIX_AGGREGATIONS, SiddhiConstants.METRIC_TYPE_FIND);
                 latencyTrackerInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT);
+                        SiddhiConstants.METRIC_INFIX_AGGREGATIONS, SiddhiConstants.METRIC_TYPE_INSERT);
 
                 throughputTrackerFind = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_FIND);
+                        SiddhiConstants.METRIC_INFIX_AGGREGATIONS, SiddhiConstants.METRIC_TYPE_FIND);
                 throughputTrackerInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                         aggregationDefinition.getId(),
-                        SiddhiConstants.METRIC_INFIX_WINDOWS, SiddhiConstants.METRIC_TYPE_INSERT);
+                        SiddhiConstants.METRIC_INFIX_AGGREGATIONS, SiddhiConstants.METRIC_TYPE_INSERT);
             }
 
             List<ExpressionExecutor> baseExecutors = cloneExpressionExecutors(processExpressionExecutorsList.get(0));

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/snapshot/SnapshotService.java
@@ -247,7 +247,9 @@ public class SnapshotService {
         } finally {
             threadBarrier.unlock();
         }
-        log.debug("Taking snapshot finished.");
+        if (log.isDebugEnabled()) {
+            log.debug("Taking snapshot finished.");
+        }
         return state;
     }
 


### PR DESCRIPTION
## Purpose
> Improve the throughput of Aggregations by validating weather debugging is enabled before debugging information is logged. #992 
> Change aggregation metric name to Aggregations from Windows (Fix for issue #993)


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


