### PR TITLE
Fix syncing event sources in an HA environment

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/InputEventHandlerCallback.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/InputEventHandlerCallback.java
@@ -23,7 +23,7 @@ import org.wso2.siddhi.core.event.Event;
  */
 public interface InputEventHandlerCallback {
 
-    void sendEvent(Event event) throws InterruptedException;
+    void sendEvent(Event event, String[] transportSyncProperties) throws InterruptedException;
 
-    void sendEvents(Event[] events) throws InterruptedException;
+    void sendEvents(Event[] events, String[] transportSyncProperties) throws InterruptedException;
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/PassThroughSourceHandler.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/PassThroughSourceHandler.java
@@ -31,12 +31,12 @@ public class PassThroughSourceHandler implements InputEventHandlerCallback {
     }
 
     @Override
-    public void sendEvent(Event event) throws InterruptedException {
+    public void sendEvent(Event event, String[] transportSyncProperties) throws InterruptedException {
         inputHandler.send(event);
     }
 
     @Override
-    public void sendEvents(Event[] events) throws InterruptedException {
+    public void sendEvents(Event[] events, String[] transportSyncProperties) throws InterruptedException {
         inputHandler.send(events);
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/Source.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/Source.java
@@ -60,7 +60,9 @@ public abstract class Source implements Snapshotable {
                            SourceHandler sourceHandler, StreamDefinition streamDefinition,
                            SiddhiAppContext siddhiAppContext) {
         this.type = sourceType;
-        sourceMapper.init(streamDefinition, mapType, mapOptionHolder, attributeMappings, sourceType, transportMappings,
+
+        sourceMapper.init(streamDefinition, mapType, mapOptionHolder, attributeMappings, sourceType,
+                (this instanceof SourceSyncCallback) ? (SourceSyncCallback) this : null, transportMappings,
                 sourceHandler, mapperConfigReader, siddhiAppContext);
         this.mapper = sourceMapper;
         this.streamDefinition = streamDefinition;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceEventListener.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceEventListener.java
@@ -29,4 +29,6 @@ public interface SourceEventListener {
     StreamDefinition getStreamDefinition();
 
     void onEvent(Object eventObject, String[] transportProperties);
+
+    void onEvent(Object eventObject, String[] transportProperties, String[] transportSyncProperties);
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceHandler.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceHandler.java
@@ -32,41 +32,40 @@ public abstract class SourceHandler implements InputEventHandlerCallback, Snapsh
     private String elementId;
     private InputHandler inputHandler;
 
-    final void initSourceHandler(String siddhiAppName, String elementId, StreamDefinition streamDefinition) {
-
+    final void initSourceHandler(String siddhiAppName, SourceSyncCallback sourceSyncCallback, String elementId,
+                                 StreamDefinition streamDefinition) {
         this.elementId = elementId;
-        init(siddhiAppName, elementId, streamDefinition);
+        init(siddhiAppName, sourceSyncCallback, elementId, streamDefinition);
     }
 
-    public abstract void init(String siddhiAppName, String elementId, StreamDefinition streamDefinition);
+    public abstract void init(String siddhiAppName, SourceSyncCallback sourceSyncCallback, String elementId,
+                              StreamDefinition streamDefinition);
 
     @Override
-    public void sendEvent(Event event) throws InterruptedException {
-
-        sendEvent(event, inputHandler);
+    public void sendEvent(Event event, String[] transportSyncProperties) throws InterruptedException {
+        sendEvent(event, transportSyncProperties, inputHandler);
     }
 
     @Override
-    public void sendEvents(Event[] events) throws InterruptedException {
-        sendEvent(events, inputHandler);
+    public void sendEvents(Event[] events, String[] transportSyncProperties) throws InterruptedException {
+        sendEvent(events, transportSyncProperties, inputHandler);
     }
 
-    public abstract void sendEvent(Event event, InputHandler inputHandler) throws InterruptedException;
+    public abstract void sendEvent(Event event, String[] transportSyncProperties, InputHandler inputHandler)
+            throws InterruptedException;
 
-    public abstract void sendEvent(Event[] events, InputHandler inputHandler) throws InterruptedException;
+    public abstract void sendEvent(Event[] events, String[] transportSyncProperties, InputHandler inputHandler)
+            throws InterruptedException;
 
     public String getElementId() {
-
         return elementId;
     }
 
     public void setInputHandler(InputHandler inputHandler) {
-
         this.inputHandler = inputHandler;
     }
 
     public InputHandler getInputHandler() {
-
         return inputHandler;
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceSyncCallback.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/stream/input/source/SourceSyncCallback.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.stream.input.source;
+
+/**
+ * Callback to get synchronous data, used for HA use cases
+ */
+public interface SourceSyncCallback {
+    void update(String[] transportSyncProperties);
+}


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to adding functionality to sync the event source transport properties between the HA nodes. 

This is the siddhi fix required for the issue: https://github.com/wso2/product-sp/issues/909

## Goals
> With the fix, a source can produce TransportSyncProperties and pass them to SourceHandler, which can synchronise the information with the passive node. Here the receiving SourceHandler can update the sources through SourceSyncCallback.

## Approach
> Update the source handlers and mappers with the source transport sync properties.

## User stories
> NA

## Release note
> NA

## Documentation
> NA

## Training
> NA

## Certification
> NA

## Marketing
> NA

## Automation tests
 - Unit tests 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> NA

## Related PRs
> NA

## Migrations (if applicable)
> NA

## Test environment
> NA
 
## Learning
> NA