### PR TITLE
Allow strings in annotation property names

### DIFF
--- a/modules/siddhi-query-compiler/src/main/antlr4/org/wso2/siddhi/query/compiler/SiddhiQL.g4
+++ b/modules/siddhi-query-compiler/src/main/antlr4/org/wso2/siddhi/query/compiler/SiddhiQL.g4
@@ -519,7 +519,7 @@ alias
     ;
 
 property_name
-    : name (property_separator name )*
+    : name (property_separator name )* | string_value
     ;
 
 attribute_name

--- a/modules/siddhi-query-compiler/src/main/java/org/wso2/siddhi/query/compiler/internal/SiddhiQLBaseVisitorImpl.java
+++ b/modules/siddhi-query-compiler/src/main/java/org/wso2/siddhi/query/compiler/internal/SiddhiQLBaseVisitorImpl.java
@@ -2366,14 +2366,17 @@ public class SiddhiQLBaseVisitorImpl extends SiddhiQLBaseVisitor {
 
         StringBuilder stringBuilder = new StringBuilder();
         List<SiddhiQLParser.NameContext> propertyNameList = ctx.name();
-        List<SiddhiQLParser.Property_separatorContext> propertySeparator = ctx.property_separator();
-        for (int i = 0; i < propertyNameList.size(); i++) {
-            stringBuilder.append(visit(propertyNameList.get(i)));
-            if (i < propertySeparator.size()) {
-                stringBuilder.append(propertySeparator.get(i).getText());
+        if (propertyNameList.size() > 0) {
+            List<SiddhiQLParser.Property_separatorContext> propertySeparator = ctx.property_separator();
+            for (int i = 0; i < propertyNameList.size(); i++) {
+                stringBuilder.append(visit(propertyNameList.get(i)));
+                if (i < propertySeparator.size()) {
+                    stringBuilder.append(propertySeparator.get(i).getText());
+                }
             }
+            return stringBuilder.toString();
         }
-        return stringBuilder.toString();
+        return visitString_value(ctx.string_value()).getValue();
     }
 
     /**


### PR DESCRIPTION
## Purpose
In Siddhi, annotation property names/keys do not allow special characters and leading numbers. This has been a limitation for some of the use cases.

## Goals
Allow string values in annotation property names, so that any value can be parsed as the key.

## Approach
Siddhi grammar has been changed to allow string values in addition to the current implementation.

```
property_name
    : name (property_separator name )* | string_value
    ;
```

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A