### PR TITLE
Added extension links for siddhi-io-prometheus

### DIFF
--- a/docs/documentation/siddhi-4.0.md
+++ b/docs/documentation/siddhi-4.0.md
@@ -143,6 +143,8 @@ The following is the list of source types that are currently supported:
 * <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-twitter/">Twitter</a>
 * <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-sqs/">Amazon SQS</a>
 * <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-cdc/">CDC</a>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-prometheus/">Prometheus</a>
+
 #### Source Mapper
 
 Each `@source` configuration has a mapping denoted by the `@map` annotation that converts the incoming messages format to Siddhi events.
@@ -254,6 +256,7 @@ The following is a list of currently supported sink types.
 * <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-mqtt/">MQTT</a>
 * <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-websocket/">WebSocket</a>
 * <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-sqs/">Amazon SQS</a>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-prometheus/">Prometheus</a>
 
 #### Distributed Sink
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -40,6 +40,7 @@ Following are some prewritten extensions that are supported with Siddhi;
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-sqs">io sqs</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-twitter">io twitter</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-cdc">io cdc</a>
+1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-prometheus">io prometheus</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-json">map json</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-xml">map xml</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-binary">map binary</a>

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -40,7 +40,6 @@ Following are some prewritten extensions that are supported with Siddhi;
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-sqs">io sqs</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-twitter">io twitter</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-cdc">io cdc</a>
-1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-prometheus">io prometheus</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-json">map json</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-xml">map xml</a>
 1. <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-binary">map binary</a>

--- a/modules/siddhi-core/siddhi-core-doc-gen/pom.xml
+++ b/modules/siddhi-core/siddhi-core-doc-gen/pom.xml
@@ -80,6 +80,7 @@
                         <extensionRepository>siddhi-io-sqs</extensionRepository>
                         <extensionRepository>siddhi-io-twitter</extensionRepository>
                         <extensionRepository>siddhi-io-cdc</extensionRepository>
+                        <extensionRepository>siddhi-io-prometheus</extensionRepository>
                         <extensionRepository>siddhi-map-json</extensionRepository>
                         <extensionRepository>siddhi-map-xml</extensionRepository>
                         <extensionRepository>siddhi-map-binary</extensionRepository>


### PR DESCRIPTION
## Purpose
> Add hyperlinks to access siddhi-io-prometheus through the documentation

## Goals
>  Providing Siddhi documentation with the links for siddhi-io-prometheus

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
