### PR TITLE
Fixes concurrent modification exception in incremental data aggregation and improves slowness in searching snapshotables. 

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataAggregator.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataAggregator.java
@@ -65,10 +65,12 @@ public class IncrementalDataAggregator {
             TimePeriod.Duration duration = incrementalDurations.get(i);
             IncrementalExecutor incrementalExecutor = incrementalExecutorMap.get(duration);
 
-            Map<String, BaseIncrementalValueStore> baseIncrementalValueStoreGroupByMap =
-                    incrementalExecutor.getBaseIncrementalValueStoreGroupByMap();
             BaseIncrementalValueStore baseIncrementalValueStore = incrementalExecutor.getBaseIncrementalValueStore();
-
+            Map<String, BaseIncrementalValueStore> baseIncrementalValueStoreGroupByMap = null;
+            if (incrementalExecutor.getBaseIncrementalValueStoreGroupByMap() != null) {
+                baseIncrementalValueStoreGroupByMap
+                        = new HashMap<>(incrementalExecutor.getBaseIncrementalValueStoreGroupByMap());
+            }
             if (baseIncrementalValueStoreGroupByMap != null) {
                 for (Map.Entry<String, BaseIncrementalValueStore> entry :
                         baseIncrementalValueStoreGroupByMap.entrySet()) {


### PR DESCRIPTION
## Purpose
> Fixes [SP-912](https://github.com/wso2/product-sp/issues/912)
> Fixes #1010 

## Goals
> Fixes concurrent modification exception in incremental data aggregation. 
> Fix the slowness in searching snapshotables. 

## Approach
> Maintain a clone of BaseIncrementalValueStoreGroupByMap while aggregating in-memory data.

> When initializing siddhi executors (function/aggregation etc) a snapshotable is added to that.
This add snapsohtable operation is slow when there is a higher number of executors being created. Using a map instead of a list to store snapshots improves the slowness while searching snapshotables. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A